### PR TITLE
Fix: issues affecting the code quality

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,9 +1,0 @@
-version = 1
-
-test_patterns = ["test/**/*_test.rb"]
-
-exclude_patterns = ["gemfiles/**"]
-
-[[analyzers]]
-name = "ruby"
-enabled = true

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,9 @@
+version = 1
+
+test_patterns = ["test/**/*_test.rb"]
+
+exclude_patterns = ["gemfiles/**"]
+
+[[analyzers]]
+name = "ruby"
+enabled = true

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -35,7 +35,7 @@ module OneLogin
         saml_request = CGI.escape(params.delete("SAMLRequest"))
         request_params = "#{params_prefix}SAMLRequest=#{saml_request}"
         params.each_pair do |key, value|
-          request_params << "&#{key.to_s}=#{CGI.escape(value.to_s)}"
+          request_params << "&#{key}=#{CGI.escape(value.to_s)}"
         end
         raise SettingError.new "Invalid settings, idp_sso_target_url is not set!" if settings.idp_sso_target_url.nil? or settings.idp_sso_target_url.empty?
         @login_url = settings.idp_sso_target_url + request_params

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -32,7 +32,7 @@ module OneLogin
         saml_request = CGI.escape(params.delete("SAMLRequest"))
         request_params = "#{params_prefix}SAMLRequest=#{saml_request}"
         params.each_pair do |key, value|
-          request_params << "&#{key.to_s}=#{CGI.escape(value.to_s)}"
+          request_params << "&#{key}=#{CGI.escape(value.to_s)}"
         end
         raise SettingError.new "Invalid settings, idp_slo_target_url is not set!" if settings.idp_slo_target_url.nil? or settings.idp_slo_target_url.empty?
         @logout_url = settings.idp_slo_target_url + request_params

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -727,7 +727,7 @@ module OneLogin
       # @return [Boolean] True if the SessionNotOnOrAfter of the AuthnStatement is valid, otherwise (when expired) False if soft=True
       # @raise [ValidationError] if soft == false and validation fails
       #
-      def validate_session_expiration()
+      def validate_session_expiration
         return true if session_expires_at.nil?
 
         now = Time.now.utc

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -727,7 +727,7 @@ module OneLogin
       # @return [Boolean] True if the SessionNotOnOrAfter of the AuthnStatement is valid, otherwise (when expired) False if soft=True
       # @raise [ValidationError] if soft == false and validation fails
       #
-      def validate_session_expiration(soft = true)
+      def validate_session_expiration(_soft = true)
         return true if session_expires_at.nil?
 
         now = Time.now.utc

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -727,7 +727,7 @@ module OneLogin
       # @return [Boolean] True if the SessionNotOnOrAfter of the AuthnStatement is valid, otherwise (when expired) False if soft=True
       # @raise [ValidationError] if soft == false and validation fails
       #
-      def validate_session_expiration(_soft = true)
+      def validate_session_expiration()
         return true if session_expires_at.nil?
 
         now = Time.now.utc

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -75,7 +75,7 @@ module OneLogin
 
         SamlMessage.schema.validate(xml).map do |schema_error|
           return false if soft
-          raise ValidationError.new("#{schema_error.message}\n\n#{xml.to_s}")
+          raise ValidationError.new("#{schema_error.message}\n\n#{xml}")
         end
       end
 

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -69,7 +69,7 @@ module OneLogin
           xml = Nokogiri::XML(document.to_s) do |config|
             config.options = XMLSecurity::BaseDocument::NOKOGIRI_OPTIONS
           end
-        rescue Exception => error
+        rescue StandardError => error
           return false if soft
           raise ValidationError.new("XML load failed: #{error.message}")
         end

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -4,7 +4,6 @@ require 'base64'
 require 'nokogiri'
 require 'rexml/document'
 require 'rexml/xpath'
-require 'thread'
 require "onelogin/ruby-saml/error_handling"
 
 # Only supports SAML 2.0

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -20,7 +20,7 @@ module OneLogin
         end
 
         config.each do |k,v|
-          acc = "#{k.to_s}=".to_sym
+          acc = "#{k}=".to_sym
           if respond_to? acc
             value = v.is_a?(Hash) ? v.dup : v
             send(acc, value)

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -218,7 +218,6 @@ module OneLogin
         OpenSSL::PKey::RSA.new(formatted_private_key)
       end
 
-      private
 
       DEFAULTS = {
         :assertion_consumer_service_binding        => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST".freeze,

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -35,7 +35,7 @@ module OneLogin
         saml_response = CGI.escape(params.delete("SAMLResponse"))
         response_params = "#{params_prefix}SAMLResponse=#{saml_response}"
         params.each_pair do |key, value|
-          response_params << "&#{key.to_s}=#{CGI.escape(value.to_s)}"
+          response_params << "&#{key}=#{CGI.escape(value.to_s)}"
         end
 
         raise SettingError.new "Invalid settings, idp_slo_target_url is not set!" if settings.idp_slo_target_url.nil? or settings.idp_slo_target_url.empty?

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -218,7 +218,7 @@ module XMLSecurity
         if options[:fingerprint_alg]
           fingerprint_alg = XMLSecurity::BaseDocument.new.algorithm(options[:fingerprint_alg]).new
         else
-          fingerprint_alg = OpenSSL::Digest::SHA1.new
+          fingerprint_alg = OpenSSL::Digest.new('SHA1')
         end
         fingerprint = fingerprint_alg.hexdigest(cert.to_der)
 


### PR DESCRIPTION
#### Description
This PR fixes a few issues that were affecting the code quality.

#### Summary of changes

- Prefer rescuing `StandardError` over `Exception`
- Prefix any unused method arguments with an underscore
- Remove redundant and unnecessary require statement
- Replaces the old OpenSSL algorithmic constants with the newer strings initializers
- Remove redundant string coercion
- Remove useless access modifiers