### PR TITLE
Support idp cert multi with string keys

### DIFF
--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -195,17 +195,13 @@ module OneLogin
 
         certs = {:signing => [], :encryption => [] }
 
-        if idp_cert_multi.key?(:signing) and not idp_cert_multi[:signing].empty?
-          idp_cert_multi[:signing].each do |idp_cert|
-            formatted_cert = OneLogin::RubySaml::Utils.format_cert(idp_cert)
-            certs[:signing].push(OpenSSL::X509::Certificate.new(formatted_cert))
-          end
-        end
+        [:signing, :encryption].each do |type|
+          certs_for_type = idp_cert_multi[type] || idp_cert_multi[type.to_s]
+          next if !certs_for_type || certs_for_type.empty?
 
-        if idp_cert_multi.key?(:encryption) and not idp_cert_multi[:encryption].empty?
-          idp_cert_multi[:encryption].each do |idp_cert|
+          certs_for_type.each do |idp_cert|
             formatted_cert = OneLogin::RubySaml::Utils.format_cert(idp_cert)
-            certs[:encryption].push(OpenSSL::X509::Certificate.new(formatted_cert))
+            certs[type].push(OpenSSL::X509::Certificate.new(formatted_cert))
           end
         end
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -972,6 +972,16 @@ class RubySamlTest < Minitest::Test
         assert_empty response_valid_signed.errors
       end
 
+      it "return true when at least a cert on idp_cert_multi is valid and keys are strings" do
+        settings.idp_cert_multi = {
+          "signing" => [ruby_saml_cert_text2, ruby_saml_cert_text],
+          "encryption" => []
+        }
+        response_valid_signed.settings = settings
+        res = response_valid_signed.send(:validate_signature)
+        assert_empty response_valid_signed.errors
+      end
+
       it "return false when none cert on idp_cert_multi is valid" do
         settings.idp_cert_fingerprint = ruby_saml_cert_fingerprint
         settings.idp_cert_multi = {

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -257,11 +257,54 @@ class SettingsTest < Minitest::Test
         assert_equal empty_multi, @settings.get_idp_cert_multi
       end
 
+      it "returns partial hash when contains some values with string keys" do
+        empty_multi = {
+          :signing => [],
+          :encryption => []
+        }
+
+        @settings.idp_cert_multi = {
+          "signing" => []
+        }
+        assert_equal empty_multi, @settings.get_idp_cert_multi
+
+        @settings.idp_cert_multi = {
+          "encryption" => []
+        }
+        assert_equal empty_multi, @settings.get_idp_cert_multi
+
+        @settings.idp_cert_multi = {
+          "signing" => [],
+          "encryption" => []
+        }
+        assert_equal empty_multi, @settings.get_idp_cert_multi
+
+        @settings.idp_cert_multi = {
+          "yyy" => [],
+          "zzz" => []
+        }
+        assert_equal empty_multi, @settings.get_idp_cert_multi
+      end
+
       it "returns the hash with certificates when values were valid" do
         certificates = ruby_saml_cert_text
         @settings.idp_cert_multi = {
           :signing => [ruby_saml_cert_text],
           :encryption => [ruby_saml_cert_text],
+        }
+
+        assert @settings.get_idp_cert_multi.kind_of? Hash
+        assert @settings.get_idp_cert_multi[:signing].kind_of? Array
+        assert @settings.get_idp_cert_multi[:encryption].kind_of? Array
+        assert @settings.get_idp_cert_multi[:signing][0].kind_of? OpenSSL::X509::Certificate
+        assert @settings.get_idp_cert_multi[:encryption][0].kind_of? OpenSSL::X509::Certificate
+      end
+
+      it "returns the hash with certificates when values were valid and with string keys" do
+        certificates = ruby_saml_cert_text
+        @settings.idp_cert_multi = {
+          "signing" => [ruby_saml_cert_text],
+          "encryption" => [ruby_saml_cert_text],
         }
 
         assert @settings.get_idp_cert_multi.kind_of? Hash


### PR DESCRIPTION
I ran into issues while attempting to integrate with an ADFS IdP.
The issue was that when settings are initialized with a hash where keys are not symbols (ex. when loaded from a json file), `Settings#get_idp_cert_multi` is not able to retrieve the certificates. 

It had been reported in this issue before: https://github.com/onelogin/ruby-saml/issues/409.

This PR proposes to fallback to string keys if symbol keys are not defined.