### PR TITLE
Drop support for Ruby < 2.6 and JRuby < 9.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04] # macos-latest
         ruby-version: [2.6, 2.7, 3.0, 3.1, 3.2, jruby-9.3, jruby-9.4, truffleruby]
         include:
           - os: macos-latest
             ruby-version: 2.6
           - os: macos-latest
+            ruby-version: 2.7
+          - os: macos-latest
             ruby-version: 3.0
+          - os: macos-latest
+            ruby-version: 3.1
           - os: macos-latest
             ruby-version: 3.2
           - os: macos-latest
             ruby-version: jruby-9.3
+          # 2023/03/07 - JRuby 9.4 on MacOS is skipped for now.
+          # Seems to be a JRuby-side issue.
+          # - os: macos-latest
+          #   ruby-version: jruby-9.4
+          - os: macos-latest
+            ruby-version: truffleruby
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -35,6 +45,8 @@ jobs:
 
       - name: Coveralls
         uses: coverallsapp/github-action@master
+        # 2023/03/07 - Simplecov is not working on TruffleRuby.
+        # TruffleRuby tests are otherwise passing.
         if: ${{ matrix.ruby-version != 'truffleruby' }}
         with:
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest]
-        ruby-version: [2.6.6, 2.7.2, 3.0.1, 3.1, 3.2, jruby-9.3.2.0, jruby-9.4.0.0, truffleruby]
+        ruby-version: [2.6, 2.7, 3.0, 3.1, 3.2, jruby-9.3, jruby-9.4, truffleruby]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04]
         ruby-version: [2.6, 2.7, 3.0, 3.1, 3.2, jruby-9.3, jruby-9.4, truffleruby]
+        include:
+          - os: macos-latest
+            ruby-version: 2.6
+          - os: macos-latest
+            ruby-version: 3.0
+          - os: macos-latest
+            ruby-version: 3.2
+          - os: macos-latest
+            ruby-version: jruby-9.3
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -26,6 +35,7 @@ jobs:
 
       - name: Coveralls
         uses: coverallsapp/github-action@master
+        if: ${{ matrix.ruby-version != 'truffleruby' }}
         with:
           github-token: ${{ secrets.github_token }}
           parallel: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest]
-        ruby-version: [2.1.9, 2.2.10, 2.3.8, 2.4.6, 2.5.8, 2.6.6, 2.7.2, 3.0.1, 3.1, 3.2, jruby-9.1.17.0, jruby-9.2.17.0, jruby-9.3.2.0, jruby-9.4.0.0, truffleruby]
+        ruby-version: [2.6.6, 2.7.2, 3.0.1, 3.1, 3.2, jruby-9.3.2.0, jruby-9.4.0.0, truffleruby]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Ruby SAML Changelog
+
 ### 1.15.0 (Jan 04, 2023)
 * [#650](https://github.com/SAML-Toolkits/ruby-saml/pull/650) Replace strip! by strip on compute_digest method
 * [#638](https://github.com/SAML-Toolkits/ruby-saml/pull/638) Fix dateTime format for the validUntil attribute of the generated metadata 

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,4 @@ gem 'mocha', '~> 2.0', require: false
 gem 'rake', '~> 13.0'
 gem 'simplecov', '~> 0.22', require: false
 gem 'simplecov-lcov', '~> 0.8', require: false
-gem 'systemu', '~> 2.6', require: false
 gem 'timecop', '~> 0.9', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,12 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'minitest', '~> 5.5'
+gem 'mocha', '~> 0.14'
+gem 'rake', '>= 12.3.3'
+gem 'shoulda', '~> 2.11'
+gem 'simplecov', '< 0.22.0'
+gem 'simplecov-lcov', '> 0.7.0'
+gem 'systemu', '~> 2'
+gem 'timecop', '~> 0.9'

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,13 @@
-#
 # Please keep this file alphabetized and organized
 #
 source 'https://rubygems.org'
 
 gemspec
 
-gem 'minitest', '~> 5.5'
-gem 'mocha', '~> 0.14'
-gem 'rake', '>= 12.3.3'
-gem 'shoulda', '~> 2.11'
-gem 'simplecov', '< 0.22.0'
-gem 'simplecov-lcov', '> 0.7.0'
-gem 'systemu', '~> 2'
-gem 'timecop', '~> 0.9'
+gem 'minitest', '~> 5.18', require: false
+gem 'mocha', '~> 2.0', require: false
+gem 'rake', '~> 13.0'
+gem 'simplecov', '~> 0.22', require: false
+gem 'simplecov-lcov', '~> 0.8', require: false
+gem 'systemu', '~> 2.6', require: false
+gem 'timecop', '~> 0.9', require: false

--- a/README.md
+++ b/README.md
@@ -20,31 +20,16 @@ We created a demo project for Rails 4 that uses the latest version of this libra
 
 ### Supported Ruby Versions
 
-The following Ruby versions are covered by CI testing:
-
-* 2.1.x
-* 2.2.x
-* 2.3.x
-* 2.4.x
-* 2.5.x
-* 2.6.x
-* 2.7.x
-* 3.0.x
+* 2.6
+* 2.7
+* 3.0
 * 3.1
 * 3.2
-* JRuby 9.1.x
-* JRuby 9.2.x
-* JRuby 9.3.X
-* JRuby 9.4.0
+* JRuby 9.3
+* JRuby 9.4
 * TruffleRuby (latest)
 
-In addition, the following may work but are untested:
-
-* 1.8.7
-* 1.9.x
-* 2.0.x
-* JRuby 1.7.x
-* JRuby 9.0.x
+For older Ruby support, please refer to older major versions of Ruby SAML.
 
 ## Adding Features, Pull Requests
 

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -202,12 +202,6 @@ module OneLogin
           http.use_ssl = true
           # Most IdPs will probably use self signed certs
           http.verify_mode = validate_cert ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
-
-          # Net::HTTP in Ruby 1.8 did not set the default certificate store
-          # automatically when VERIFY_PEER was specified.
-          if RUBY_VERSION < '1.9' && !http.ca_file && !http.ca_path && !http.cert_store
-            http.cert_store = OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE
-          end
         end
 
         get = Net::HTTP::Get.new(uri.request_uri)

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -973,12 +973,7 @@ module OneLogin
           raise ValidationError.new('An EncryptedAssertion found and no SP private key found on the settings to decrypt it. Be sure you provided the :settings parameter at the initialize method')
         end
 
-        # Marshal at Ruby 1.8.7 throw an Exception
-        if RUBY_VERSION < "1.9"
-          document_copy = XMLSecurity::SignedDocument.new(response, errors)
-        else
-          document_copy = Marshal.load(Marshal.dump(document))
-        end
+        document_copy = Marshal.load(Marshal.dump(document))
 
         decrypt_assertion_from_document(document_copy)
       end

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -1,8 +1,4 @@
-if RUBY_VERSION < '1.9'
-  require 'uuid'
-else
-  require 'securerandom'
-end
+require 'securerandom'
 require "openssl"
 
 module OneLogin
@@ -11,8 +7,6 @@ module OneLogin
     # SAML2 Auxiliary class
     #
     class Utils
-      @@uuid_generator = UUID.new if RUBY_VERSION < '1.9'
-
       BINDINGS = { :post => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST".freeze,
                    :redirect => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect".freeze }.freeze
       DSIG = "http://www.w3.org/2000/09/xmldsig#".freeze
@@ -56,8 +50,6 @@ module OneLogin
       # @return [Integer] The new timestamp, after the duration is applied.
       #
       def self.parse_duration(duration, timestamp=Time.now.utc)
-        return nil if RUBY_VERSION < '1.9'  # 1.8.7 not supported
-
         matches = duration.match(DURATION_FORMAT)
 
         if matches.nil?
@@ -348,7 +340,7 @@ module OneLogin
       end
 
       def self.uuid
-        "#{UUID_PREFIX}" + (RUBY_VERSION < '1.9' ? "#{@@uuid_generator.generate}" : "#{SecureRandom.uuid}")
+        "#{UUID_PREFIX}#{SecureRandom.uuid}"
       end
 
       # Given two strings, attempt to match them as URIs using Rails' parse method.  If they can be parsed,

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -20,85 +20,9 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 2.6.0'
   s.summary = %q{SAML Ruby Tookit}
 
-  # Because runtime dependencies are determined at build time, we cannot make
-  # Nokogiri's version dependent on the Ruby version, even though we would
-  # have liked to constrain Ruby 1.8.7 to install only the 1.5.x versions.
-  if defined?(JRUBY_VERSION)
-    if JRUBY_VERSION < '9.1.7.0'
-      s.add_runtime_dependency('nokogiri', '>= 1.8.2', '<= 1.8.5')
-      s.add_runtime_dependency('jruby-openssl', '>= 0.9.8')
-      s.add_runtime_dependency('json', '< 2.3.0')
-    elsif JRUBY_VERSION < '9.2.0.0'
-      s.add_runtime_dependency('nokogiri', '>= 1.9.1', '< 1.10.0')
-    elsif JRUBY_VERSION < '9.3.2.0'
-      s.add_runtime_dependency('nokogiri', '>= 1.11.4')
-      s.add_runtime_dependency('rexml')
-    else
-      s.add_runtime_dependency('nokogiri', '>= 1.13.10')
-      s.add_runtime_dependency('rexml')
-    end
-  elsif RUBY_VERSION < '1.9'
-    s.add_runtime_dependency('uuid')
-    s.add_runtime_dependency('nokogiri', '<= 1.5.11')
-  elsif RUBY_VERSION < '2.1'
-    s.add_runtime_dependency('nokogiri', '>= 1.5.10', '<= 1.6.8.1')
-    s.add_runtime_dependency('json', '< 2.3.0')
-  elsif RUBY_VERSION < '2.3'
-    s.add_runtime_dependency('nokogiri', '>= 1.9.1', '< 1.10.0')
-  elsif RUBY_VERSION < '2.5'
-    s.add_runtime_dependency('nokogiri', '>= 1.10.10', '< 1.11.0')
-    s.add_runtime_dependency('rexml')
-  elsif RUBY_VERSION < '2.6'
-    s.add_runtime_dependency('nokogiri', '>= 1.11.4')
-    s.add_runtime_dependency('rexml')
-  else
-    s.add_runtime_dependency('nokogiri', '>= 1.13.10')
-    s.add_runtime_dependency('rexml')
-  end
-
-  s.add_development_dependency('simplecov', '<0.22.0')
-  if RUBY_VERSION < '2.4.1'
-    s.add_development_dependency('simplecov-lcov', '<0.8.0')
-  else
-    s.add_development_dependency('simplecov-lcov', '>0.7.0')
-  end
-
-  s.add_development_dependency('minitest', '~> 5.5')
-  s.add_development_dependency('mocha',    '~> 0.14')
-
-  if RUBY_VERSION < '2.0'
-    s.add_development_dependency('rake',     '~> 10')
-  else
-    s.add_development_dependency('rake',     '>= 12.3.3')
-  end
-
-  s.add_development_dependency('shoulda',  '~> 2.11')
-  s.add_development_dependency('systemu',  '~> 2')
-
-  if RUBY_VERSION < '2.1'
-    s.add_development_dependency('timecop',  '<= 0.6.0')
-  else
-    s.add_development_dependency('timecop',  '~> 0.9')
-  end
-
-  if defined?(JRUBY_VERSION)
-    # All recent versions of JRuby play well with pry
-    s.add_development_dependency('pry')
-  elsif RUBY_VERSION < '1.9'
-    # 1.8.7
-    s.add_development_dependency('ruby-debug', '~> 0.10.4')
-  elsif RUBY_VERSION < '2.0'
-    # 1.9.x
-    s.add_development_dependency('debugger-linecache', '~> 1.2.0')
-    s.add_development_dependency('debugger', '~> 1.6.4')
-  elsif RUBY_VERSION < '2.1'
-    # 2.0.x
-    s.add_development_dependency('byebug', '~> 2.1.1')
-  else
-    # 2.1.x, 2.2.x
-    s.add_development_dependency('pry-byebug')
-  end
+  s.add_dependency('nokogiri', '>= 1.13.10')
+  s.add_dependency('rexml')
 end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), 'test_helper'))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/attributes'
 

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/idp_metadata_parser'
 

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -419,7 +419,6 @@ class IdpMetadataParserTest < Minitest::Test
     end
 
     it "if no ValidUntil but CacheDuration return CacheDuration converted in ValidUntil" do
-      return if RUBY_VERSION < '1.9'
       Timecop.freeze(Time.parse("2020-01-02T10:02:33Z", Time.now.utc)) do
         settings = @idp_metadata_parser.parse(idp_metadata_descriptor5)
         assert_equal '2020-01-03T10:02:33Z', settings.valid_until
@@ -427,8 +426,6 @@ class IdpMetadataParserTest < Minitest::Test
     end
 
     it "if ValidUntil and CacheDuration return the sooner timestamp" do
-      return if RUBY_VERSION < '1.9'
-
       Timecop.freeze(Time.parse("2020-01-01T10:12:55Z", Time.now.utc)) do
         settings = @idp_metadata_parser.parse(idp_metadata_descriptor6)
         assert_equal '2020-01-03T10:12:55Z', settings.valid_until

--- a/test/logging_test.rb
+++ b/test/logging_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/logging'
 

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/logoutrequest'
 

--- a/test/logoutresponse_test.rb
+++ b/test/logoutresponse_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/logoutresponse'
 require 'logout_responses/logoutresponse_fixtures'

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/metadata'
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/authrequest'
 require 'onelogin/ruby-saml/setting_error'

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/response'
 

--- a/test/saml_message_test.rb
+++ b/test/saml_message_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 class RubySamlTest < Minitest::Test
 

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/settings'
 require 'onelogin/ruby-saml/validation_error'

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 require 'logout_responses/logoutresponse_fixtures'
 
 require 'onelogin/ruby-saml/slo_logoutrequest'

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 require 'onelogin/ruby-saml/slo_logoutresponse'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,15 @@
-require 'simplecov'
-require 'simplecov-lcov'
-
-SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
-SimpleCov::Formatter::LcovFormatter.config.output_directory = 'coverage'
-SimpleCov::Formatter::LcovFormatter.config.lcov_file_name = 'lcov.info'
-SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
-SimpleCov.start do
-  add_filter "test/"
-  add_filter "vendor/"
-  add_filter "lib/onelogin/ruby-saml/logging.rb"
+unless defined?(TruffleRuby)
+  require 'simplecov'
+  require 'simplecov-lcov'
+  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+  SimpleCov::Formatter::LcovFormatter.config.output_directory = 'coverage'
+  SimpleCov::Formatter::LcovFormatter.config.lcov_file_name = 'lcov.info'
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+  SimpleCov.start do
+    add_filter "test/"
+    add_filter "vendor/"
+    add_filter "lib/onelogin/ruby-saml/logging.rb"
+  end
 end
 
 require 'stringio'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# 2023/03/07 - Simplecov is not working on TruffleRuby.
 unless defined?(TruffleRuby)
   require 'simplecov'
   require 'simplecov-lcov'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,7 @@ require 'stringio'
 require 'rubygems'
 require 'bundler'
 require 'minitest/autorun'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'timecop'
 
 Bundler.require :default, :test

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 
 class UtilsTest < Minitest::Test
   describe ".parse_duration" do

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -22,7 +22,6 @@ class UtilsTest < Minitest::Test
     }
 
     def result(duration, reference = 0)
-      return nil if RUBY_VERSION < '1.9'
       Time.at(
         OneLogin::RubySaml::Utils.parse_duration(duration, reference)
       ).utc.iso8601(3)
@@ -30,14 +29,12 @@ class UtilsTest < Minitest::Test
 
     DURATIONS_FROM_EPOCH.each do |duration, expected|
       it "parses #{duration} to return #{expected} from the given timestamp" do
-        return if RUBY_VERSION < '1.9'
         assert_equal expected, result(duration)
       end
     end
 
     it "returns the last calendar day of the next month when advancing from a longer month to a shorter one" do
       initial_timestamp = Time.iso8601("1970-01-31T00:00:00.000Z").to_i
-      return if RUBY_VERSION < '1.9'
       assert_equal "1970-02-28T00:00:00.000Z", result("P1M", initial_timestamp)
     end
   end

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+require_relative 'test_helper'
 require 'xml_security'
 
 class XmlSecurityTest < Minitest::Test


### PR DESCRIPTION
Fixes https://github.com/onelogin/ruby-saml/issues/608

This PR removes support for Ruby < 2.1 and JRuby < jruby-9.1