### PR TITLE
Add Option (strict_cert_store) to disallow X.509 in requests when idp_cert is provided in settings

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -205,6 +205,8 @@ module XMLSecurity
       )
 
       if cert_element
+        options[:strict_cert_store] && append_error("Certificate element provided (ds:X509Certificate) when disallowed", soft)
+
         base64_cert = OneLogin::RubySaml::Utils.element_text(cert_element)
         cert_text = Base64.decode64(base64_cert)
         begin

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -77,6 +77,15 @@ class XmlSecurityTest < Minitest::Test
       assert_equal("Certificate element missing in response (ds:X509Certificate) and not cert provided at settings", exception.message)
     end
 
+    it "raise validation error when an X509 Certificate is provided and strict idp cert storage is set" do
+      cert = OpenSSL::X509::Certificate.new(ruby_saml_cert)
+      mod_document = XMLSecurity::SignedDocument.new(decoded_response)
+      exception = assert_raises(OneLogin::RubySaml::ValidationError) do
+        mod_document.validate_document("a fingerprint", false, { cert: cert, strict_cert_store: true }) # The fingerprint isn't relevant to this test
+      end
+      assert_equal("Certificate element provided (ds:X509Certificate) when disallowed", exception.message)
+    end
+
     it "invalidaties when the X509Certificate is missing and the cert is provided but mismatches" do
       decoded_response.sub!(/<ds:X509Certificate>.*<\/ds:X509Certificate>/, "")
       mod_document = XMLSecurity::SignedDocument.new(decoded_response)


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
We'd like to ensure that configurations which make use of the idp_cert stored in the `settings` object do not use an X.509 certificate provided from the IdP when validating the signature of the response.

## Motivation
When using traditional X.509 based signature validation and the SHA-1 signing algorithms our end users are concerned that one may spoof a request using a different public / private key pair due to the potential of checksum collisions using SHA-1. 

In order to address this, we migrated to using idp_certs stored in the saml settings, though one may still provide an X509 certificate in a request and it will be evaluated prior to using the public key stored in the settings object.

(We also migrated to using SHA-256 as the signing algorithm, though this flexibility would still be useful to us in reassuring our end users)