### PR TITLE
Output a valid XML `dateTime` for the `validUntil` metadata property

### DIFF
--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -49,7 +49,7 @@ module OneLogin
         root = meta_doc.add_element("md:EntityDescriptor", namespaces)
         root.attributes["ID"] = OneLogin::RubySaml::Utils.uuid
         root.attributes["entityID"] = settings.sp_entity_id if settings.sp_entity_id
-        root.attributes["validUntil"] = valid_until.strftime('%Y-%m-%dT%H:%M:%S%z') if valid_until
+        root.attributes["validUntil"] = valid_until.utc.strftime('%Y-%m-%dT%H:%M:%SZ') if valid_until
         root.attributes["cacheDuration"] = "PT" + cache_duration.to_s + "S" if cache_duration
         root
       end

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -83,7 +83,7 @@ class MetadataTest < Minitest::Test
       assert_equal xml_metadata[0..start.length-1],start
 
       doc_metadata = REXML::Document.new(xml_metadata)
-      assert_equal valid_until.strftime('%Y-%m-%dT%H:%M:%S%z'), REXML::XPath.first(doc_metadata, "//md:EntityDescriptor").attribute("validUntil").value
+      assert_equal valid_until.strftime('%Y-%m-%dT%H:%M:%SZ'), REXML::XPath.first(doc_metadata, "//md:EntityDescriptor").attribute("validUntil").value
       assert_equal "PT604800S", REXML::XPath.first(doc_metadata, "//md:EntityDescriptor").attribute("cacheDuration").value
     end
 


### PR DESCRIPTION
The XML generated prior to this change was considered invalid, according to samltool.com's XML validator. An example metadata XML document:

```xml
<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="_a881df95-a3e4-43df-a340-47742de4c356" entityID="..." validUntil="2022-06-15T03:03:01+0000">
<md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="..." index="0" isDefault="true"/>
</md:SPSSODescriptor>
</md:EntityDescriptor>
```

The `+0000` is the culprit, with the following validation error received from samltool.com:

```
Line: 1 | Column: 0  --> Element '{urn:oasis:names:tc:SAML:2.0:metadata}EntityDescriptor', attribute 'validUntil': '2022-06-15T03:03:01+0000' is not a valid value of the atomic type 'xs:dateTime'.
```

Additionally, should someone pass a non-UTC time for `validUntil`, that also produced invalid XML.

Now, we coerce the provided `validUntil` into a UTC time, and hard-code a `Z` at the end of the format, to consistently produce valid XML.