### PR TITLE
Replace strip! by strip on compute_digest method

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -177,7 +177,7 @@ module XMLSecurity
 
     def compute_digest(document, digest_algorithm)
       digest = digest_algorithm.digest(document)
-      Base64.encode64(digest).strip!
+      Base64.encode64(digest).strip
     end
 
   end


### PR DESCRIPTION
This PR replaces #647, Issue reported at #603

@bramleyjl This PR contains only 1 commit vs the one you created with 6 commits.

This PR is for a fix to the compute_digest method that was rendering a nil digest after Base64-encoding it. The reason for this bug is the usage of [strip!](https://apidock.com/ruby/v2_5_5/String/strip%21), a method that returns nil if no whitespace is found on either end of the string to be [strip](https://apidock.com/ruby/v2_5_5/String/strip)ped. By replacing it with strip, an identical method that will return the original string if no whitespace is found to be stripped, this bug can be prevented.