### PR TITLE
Forward soft argument to validate_signature

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -262,7 +262,7 @@ module XMLSecurity
       else
         base64_cert = Base64.encode64(idp_cert.to_pem)
       end
-      validate_signature(base64_cert, true)
+      validate_signature(base64_cert, soft)
     end
 
     def validate_signature(base64_cert, soft = true)


### PR DESCRIPTION
When calling the `validate_document` method chain, the `soft` parameter is passed down from one method to another except in the hand off from `validate_document_with_cert` to `validate_signature`.