### PR TITLE
Patch errant bullet point without space in Changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 * Support Process Transform
 * Raise SettingError if invoking an action with no endpoint defined on the settings
 * Made IdpMetadataParser more extensible for subclasses
-*[#548](https://github.com/onelogin/ruby-saml/pull/548) Add :skip_audience option
+* [#548](https://github.com/onelogin/ruby-saml/pull/548) Add :skip_audience option
 * [#555](https://github.com/onelogin/ruby-saml/pull/555) Define 'soft' variable to prevent exception when doc cert is invalid
 * Improve documentation
 


### PR DESCRIPTION
Fixes display of bullet point about #548 in [1.12.0 changelog](https://github.com/Capncavedan/ruby-saml/blob/master/CHANGELOG.md#1120-feb-18-2021)

Before:

<img width="854" alt="image" src="https://github.com/SAML-Toolkits/ruby-saml/assets/683970/e58e17ed-f7ba-49f8-aaaf-701edf58dac4">


After:

<img width="753" alt="image" src="https://github.com/SAML-Toolkits/ruby-saml/assets/683970/2e18004f-7ce1-4a0a-8870-761fc84051ee">
