### PR TITLE
Correct reference to issuer / idp_entity_id (was sp_entity_id)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,7 +24,7 @@ in favor of `idp_sso_service_url` and `idp_slo_service_url`. The `IdpMetadataPar
 
 ## Upgrading from 1.10.x to 1.11.0
 
-Version `1.11.0` deprecates the use of `settings.issuer` in favour of `settings.sp_entity_id`.
+Version `1.11.0` deprecates the use of `settings.issuer` in favour of `settings.idp_entity_id`.
 There are two new security settings: `settings.security[:check_idp_cert_expiration]` and
 `settings.security[:check_sp_cert_expiration]` (both false by default) that check if the
 IdP or SP X.509 certificate has expired, respectively.


### PR DESCRIPTION
I believe [this note](https://github.com/SAML-Toolkits/ruby-saml/pull/670) referencing `sp_entity_id` in the upgrade guide is incorrect, and should reference `idp_entity_id` instead.

> deprecates the use of `settings.issuer` in favour of `settings.sp_entity_id`