### PR TITLE
Add sp_cert_multi to facilitate SP cert/key rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Ruby SAML Changelog
+
+### 1.17.0
+* [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) Add `Settings#sp_cert_multi` paramter to facilitate SP certificate and key rotation.
+* [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) Support multiple simultaneous SP decryption keys via `Settings#sp_cert_multi` parameter.
+* [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) Deprecate `Settings#certificate_new` parameter.
+* [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) `:check_sp_cert_expiration` will use the first non-expired certificate/key when signing/decrypting. It will raise an error only if there are no valid certificates/keys.
+* [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) `:check_sp_cert_expiration` now validates the certificate `not_before` condition; previously it was only validating `not_after`.
+* [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) `:check_sp_cert_expiration` now causes the generated SP metadata to exclude any inactive/expired certificates.
+
 ### 1.16.0 (Oct 09, 2023)
 * [#671](https://github.com/SAML-Toolkits/ruby-saml/pull/671) Add support on LogoutRequest with Encrypted NameID
 
 ### 1.15.0 (Jan 04, 2023)
 * [#650](https://github.com/SAML-Toolkits/ruby-saml/pull/650) Replace strip! by strip on compute_digest method
 * [#638](https://github.com/SAML-Toolkits/ruby-saml/pull/638) Fix dateTime format for the validUntil attribute of the generated metadata 
-* [#576](https://github.com/SAML-Toolkits/ruby-saml/pull/576) Support idp cert multi with string keys
+* [#576](https://github.com/SAML-Toolkits/ruby-saml/pull/576) Support `Settings#idp_cert_multi` with string keys
 * [#567](https://github.com/SAML-Toolkits/ruby-saml/pull/567) Improve Code quality
 * Add info about new repo, new maintainer, new security contact
 * Fix tests, Adjust dependencies, Add ruby 3.2 and new jruby versions tests to the CI. Add coveralls support

--- a/README.md
+++ b/README.md
@@ -735,6 +735,48 @@ validation fails. You may disable such exceptions using the `settings.security[:
   settings.security[:soft] = true  # Do not raise error on failed signature/certificate validations
 ```
 
+#### Advanced SP Certificate Usage & Key Rollover
+
+Ruby SAML provides the `settings.sp_cert_multi` parameter to enable the following
+advanced usage scenarios:
+- Rotating SP certificates and private keys without disruption of service.
+- Specifying separate SP certificates for signing and encryption.
+
+The `sp_cert_multi` parameter replaces `certificate` and `private_key`
+(you may not specify both pparameters at the same time.) `sp_cert_multi` has the following shape:
+
+```ruby
+settings.sp_cert_multi = {
+  signing: [
+    { certificate: cert1, private_key: private_key1 },
+    { certificate: cert2, private_key: private_key2 }
+  ],
+  encryption: [
+    { certificate: cert1, private_key: private_key1 },
+    { certificate: cert3, private_key: private_key1 }
+  ],
+}
+```
+
+Certificate rotation is acheived by inserting new certificates at the bottom of each list,
+and then removing the old certificates from the top of the list once your IdPs have migrated.
+A common practice is for apps to publish the current SP metadata at a URL endpoint and have
+the IdP regularly poll for updates.
+
+Note the following:
+- You may re-use the same certificate and/or private key in multiple places, including for both signing and encryption.
+- The IdP should attempt to verify signatures with *all* `:signing` certificates,
+  and permit if *any one* succeeds. When signing, Ruby SAML will use the first SP certificate
+  in the `sp_cert_multi[:signing]` array. This will be the first active/non-expired certificate
+  in the array if `settings.security[:check_sp_cert_expiration]` is true.
+- The IdP may encrypt with any of the SP certificates in the `sp_cert_multi[:encryption]`
+  array. When decrypting, Ruby SAML attempt to decrypt with each SP private key in
+  `sp_cert_multi[:encryption]` until the decryption is successful. This will skip private
+  keys for inactive/expired certificates if `:check_sp_cert_expiration` is true.
+- If `:check_sp_cert_expiration` is true, the generated SP metadata XML will not include
+  inactive/expired certificates. This avoids validation errors when the IdP reads the SP
+  metadata.
+
 #### Audience Validation
 
 A service provider should only consider a SAML response valid if the IdP includes an <AudienceRestriction>
@@ -756,29 +798,6 @@ is invalid using the `settings.security[:strict_audience_validation]` parameter.
 
 ```ruby
 settings.security[:strict_audience_validation] = true
-```
-
-#### Key Rollover
-
-To update the SP X.509 certificate and private key without disruption of service, you may define the parameter
-`settings.certificate_new`. This will publish the new SP certificate in your metadata so that your IdP counterparties
-may cache it in preparation for rollover.
-
-For example, if you to rollover from `CERT A` to `CERT B`. Before rollover, your settings should look as follows.
-Both `CERT A` and `CERT B` will now appear in your SP metadata, however `CERT A` will still be used for signing
-and encryption at this time.
-
-```ruby
-  settings.certificate = "CERT A"
-  settings.private_key = "PRIVATE KEY FOR CERT A"
-  settings.certificate_new = "CERT B"
-```
-
-After the IdP has cached `CERT B`, you may then change your settings as follows:
-
-```ruby
-  settings.certificate = "CERT B"
-  settings.private_key = "PRIVATE KEY FOR CERT B"
 ```
 
 ## Single Log Out

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -69,8 +69,9 @@ module OneLogin
         request = deflate(request) if settings.compress_request
         base64_request = encode(request)
         request_params = {"SAMLRequest" => base64_request}
+        sp_signing_key = settings.get_sp_signing_key
 
-        if settings.idp_slo_service_binding == Utils::BINDINGS[:redirect] && settings.security[:logout_requests_signed] && settings.private_key
+        if settings.idp_slo_service_binding == Utils::BINDINGS[:redirect] && settings.security[:logout_requests_signed] && sp_signing_key
           params['SigAlg'] = settings.security[:signature_method]
           url_string = OneLogin::RubySaml::Utils.build_query(
             :type => 'SAMLRequest',
@@ -79,7 +80,7 @@ module OneLogin
             :sig_alg => params['SigAlg']
           )
           sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
-          signature = settings.get_sp_key.sign(sign_algorithm.new, url_string)
+          signature = settings.get_sp_signing_key.sign(sign_algorithm.new, url_string)
           params['Signature'] = encode(signature)
         end
 
@@ -138,9 +139,8 @@ module OneLogin
 
       def sign_document(document, settings)
         # embed signature
-        if settings.idp_slo_service_binding == Utils::BINDINGS[:post] && settings.security[:logout_requests_signed] && settings.private_key && settings.certificate
-          private_key = settings.get_sp_key
-          cert = settings.get_sp_cert
+        cert, private_key = settings.get_sp_signing_pair
+        if settings.idp_slo_service_binding == Utils::BINDINGS[:post] && settings.security[:logout_requests_signed] && private_key && cert
           document.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
         end
 

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -62,29 +62,14 @@ module OneLogin
         }
       end
 
-      # Add KeyDescriptor if messages will be signed / encrypted
-      # with SP certificate, and new SP certificate if any
+      # Add KeyDescriptor elements for SP certificates.
       def add_sp_certificates(sp_sso, settings)
-        cert = settings.get_sp_cert
-        cert_new = settings.get_sp_cert_new
+        certs = settings.get_sp_certs
 
-        for sp_cert in [cert, cert_new]
-          if sp_cert
-            cert_text = Base64.encode64(sp_cert.to_der).gsub("\n", '')
-            kd = sp_sso.add_element "md:KeyDescriptor", { "use" => "signing" }
-            ki = kd.add_element "ds:KeyInfo", {"xmlns:ds" => "http://www.w3.org/2000/09/xmldsig#"}
-            xd = ki.add_element "ds:X509Data"
-            xc = xd.add_element "ds:X509Certificate"
-            xc.text = cert_text
+        certs[:signing].each { |cert, _| add_sp_cert_element(sp_sso, cert, :signing) }
 
-            if settings.security[:want_assertions_encrypted]
-              kd2 = sp_sso.add_element "md:KeyDescriptor", { "use" => "encryption" }
-              ki2 = kd2.add_element "ds:KeyInfo", {"xmlns:ds" => "http://www.w3.org/2000/09/xmldsig#"}
-              xd2 = ki2.add_element "ds:X509Data"
-              xc2 = xd2.add_element "ds:X509Certificate"
-              xc2.text = cert_text
-            end
-          end
+        if settings.security[:want_assertions_encrypted]
+          certs[:encryption].each { |cert, _| add_sp_cert_element(sp_sso, cert, :encryption) }
         end
 
         sp_sso
@@ -153,8 +138,7 @@ module OneLogin
       def embed_signature(meta_doc, settings)
         return unless settings.security[:metadata_signed]
 
-        private_key = settings.get_sp_key
-        cert = settings.get_sp_cert
+        cert, private_key = settings.get_sp_signing_pair
         return unless private_key && cert
 
         meta_doc.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
@@ -171,6 +155,18 @@ module OneLogin
         end
 
         ret
+      end
+
+      private
+
+      def add_sp_cert_element(sp_sso, cert, use)
+        return unless cert
+        cert_text = Base64.encode64(cert.to_der).gsub("\n", '')
+        kd = sp_sso.add_element "md:KeyDescriptor", { "use" => use.to_s }
+        ki = kd.add_element "ds:KeyInfo", { "xmlns:ds" => "http://www.w3.org/2000/09/xmldsig#" }
+        xd = ki.add_element "ds:X509Data"
+        xc = xd.add_element "ds:X509Certificate"
+        xc.text = cert_text
       end
     end
   end

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -60,8 +60,8 @@ module OneLogin
       attr_accessor :attributes_index
       attr_accessor :force_authn
       attr_accessor :certificate
-      attr_accessor :certificate_new
       attr_accessor :private_key
+      attr_accessor :sp_cert_multi
       attr_accessor :authn_context
       attr_accessor :authn_context_comparison
       attr_accessor :authn_context_decl_ref
@@ -70,6 +70,7 @@ module OneLogin
       attr_accessor :security
       attr_accessor :soft
       # Deprecated
+      attr_accessor :certificate_new
       attr_accessor :assertion_consumer_logout_service_url
       attr_reader   :assertion_consumer_logout_service_binding
       attr_accessor :issuer
@@ -180,10 +181,7 @@ module OneLogin
       # @return [OpenSSL::X509::Certificate|nil] Build the IdP certificate from the settings (previously format it)
       #
       def get_idp_cert
-        return nil if idp_cert.nil? || idp_cert.empty?
-
-        formatted_cert = OneLogin::RubySaml::Utils.format_cert(idp_cert)
-        OpenSSL::X509::Certificate.new(formatted_cert)
+        OneLogin::RubySaml::Utils.build_cert_object(idp_cert)
       end
 
       # @return [Hash with 2 arrays of OpenSSL::X509::Certificate] Build multiple IdP certificates from the settings.
@@ -191,7 +189,7 @@ module OneLogin
       def get_idp_cert_multi
         return nil if idp_cert_multi.nil? || idp_cert_multi.empty?
 
-        raise ArgumentError.new("Invalid value for idp_cert_multi") if not idp_cert_multi.is_a?(Hash)
+        raise ArgumentError.new("Invalid value for idp_cert_multi") unless idp_cert_multi.is_a?(Hash)
 
         certs = {:signing => [], :encryption => [] }
 
@@ -200,49 +198,70 @@ module OneLogin
           next if !certs_for_type || certs_for_type.empty?
 
           certs_for_type.each do |idp_cert|
-            formatted_cert = OneLogin::RubySaml::Utils.format_cert(idp_cert)
-            certs[type].push(OpenSSL::X509::Certificate.new(formatted_cert))
+            certs[type].push(OneLogin::RubySaml::Utils.build_cert_object(idp_cert))
           end
         end
 
         certs
       end
 
-      # @return [OpenSSL::X509::Certificate|nil] Build the SP certificate from the settings (previously format it)
-      #
-      def get_sp_cert
-        return nil if certificate.nil? || certificate.empty?
+      # @return [Hash<Symbol, Array<Array<OpenSSL::X509::Certificate, OpenSSL::PKey::RSA>>>]
+      #   Build the SP certificates and private keys from the settings. If
+      #   check_sp_cert_expiration is true, only returns certificates and private keys
+      #   that are not expired.
+      def get_sp_certs
+        certs = get_all_sp_certs
+        return certs unless security[:check_sp_cert_expiration]
 
-        formatted_cert = OneLogin::RubySaml::Utils.format_cert(certificate)
-        cert = OpenSSL::X509::Certificate.new(formatted_cert)
+        active_certs = { signing: [], encryption: [] }
+        certs.each do |use, pairs|
+          next if pairs.empty?
 
-        if security[:check_sp_cert_expiration]
-          if OneLogin::RubySaml::Utils.is_cert_expired(cert)
-            raise OneLogin::RubySaml::ValidationError.new("The SP certificate expired.")
-          end
+          pairs = pairs.select { |cert, _| !cert || OneLogin::RubySaml::Utils.is_cert_active(cert) }
+          raise OneLogin::RubySaml::ValidationError.new("The SP certificate expired.") if pairs.empty?
+
+          active_certs[use] = pairs.freeze
         end
-
-        cert
+        active_certs.freeze
       end
 
-      # @return [OpenSSL::X509::Certificate|nil] Build the New SP certificate from the settings (previously format it)
+      # @return [Array<OpenSSL::X509::Certificate, OpenSSL::PKey::RSA>]
+      #   The SP signing certificate and private key.
+      def get_sp_signing_pair
+        get_sp_certs[:signing].first
+      end
+
+      # @return [OpenSSL::X509::Certificate] The SP signing certificate.
+      # @deprecated Use get_sp_signing_pair or get_sp_certs instead.
+      def get_sp_cert
+        node = get_sp_signing_pair
+        node[0] if node
+      end
+
+      # @return [OpenSSL::PKey::RSA] The SP signing key.
+      def get_sp_signing_key
+        node = get_sp_signing_pair
+        node[1] if node
+      end
+
+      # @deprecated Use get_sp_signing_key or get_sp_certs instead.
+      alias_method :get_sp_key, :get_sp_signing_key
+
+      # @return [Array<OpenSSL::PKey::RSA>] The SP decryption keys.
+      def get_sp_decryption_keys
+        ary = get_sp_certs[:encryption].map { |pair| pair[1] }
+        ary.compact!
+        ary.uniq!(&:to_pem)
+        ary.freeze
+      end
+
+      # @return [OpenSSL::X509::Certificate|nil] Build the New SP certificate from the settings.
       #
+      # @deprecated Use get_sp_certs instead
       def get_sp_cert_new
-        return nil if certificate_new.nil? || certificate_new.empty?
-
-        formatted_cert = OneLogin::RubySaml::Utils.format_cert(certificate_new)
-        OpenSSL::X509::Certificate.new(formatted_cert)
+        node = get_sp_certs[:signing].last
+        node[0] if node
       end
-
-      # @return [OpenSSL::PKey::RSA] Build the SP private from the settings (previously format it)
-      #
-      def get_sp_key
-        return nil if private_key.nil? || private_key.empty?
-
-        formatted_private_key = OneLogin::RubySaml::Utils.format_private_key(private_key)
-        OpenSSL::PKey::RSA.new(formatted_private_key)
-      end
-
 
       def idp_binding_from_embed_sign
         security[:embed_sign] ? Utils::BINDINGS[:post] : Utils::BINDINGS[:redirect]
@@ -280,6 +299,85 @@ module OneLogin
           :lowercase_url_encoding     => false
         }.freeze
       }.freeze
+
+      private
+
+      # @return [Hash<Symbol, Array<Array<OpenSSL::X509::Certificate, OpenSSL::PKey::RSA>>>]
+      #   Build the SP certificates and private keys from the settings. Returns all
+      #   certificates and private keys, even if they are expired.
+      def get_all_sp_certs
+        validate_sp_certs_params!
+        get_sp_certs_multi || get_sp_certs_single
+      end
+
+      # Validate certificate, certificate_new, private_key, and sp_cert_multi params.
+      def validate_sp_certs_params!
+        multi    = sp_cert_multi   && !sp_cert_multi.empty?
+        cert     = certificate     && !certificate.empty?
+        cert_new = certificate_new && !certificate_new.empty?
+        pk       = private_key     && !private_key.empty?
+        if multi && (cert || cert_new || pk)
+          raise ArgumentError.new("Cannot specify both sp_cert_multi and certificate, certificate_new, private_key parameters")
+        end
+      end
+
+      # Get certs from certificate, certificate_new, and private_key parameters.
+      def get_sp_certs_single
+        certs = { :signing => [], :encryption => [] }
+
+        sp_key = OneLogin::RubySaml::Utils.build_private_key_object(private_key)
+        cert = OneLogin::RubySaml::Utils.build_cert_object(certificate)
+        if cert || sp_key
+          ary = [cert, sp_key].freeze
+          certs[:signing] << ary
+          certs[:encryption] << ary
+        end
+
+        cert_new = OneLogin::RubySaml::Utils.build_cert_object(certificate_new)
+        if cert_new
+          ary = [cert_new, sp_key].freeze
+          certs[:signing] << ary
+          certs[:encryption] << ary
+        end
+
+        certs
+      end
+
+      # Get certs from get_sp_cert_multi parameter.
+      def get_sp_certs_multi
+        return if sp_cert_multi.nil? || sp_cert_multi.empty?
+
+        raise ArgumentError.new("sp_cert_multi must be a Hash") unless sp_cert_multi.is_a?(Hash)
+
+        certs = { :signing => [], :encryption => [] }.freeze
+
+        [:signing, :encryption].each do |type|
+          certs_for_type = sp_cert_multi[type] || sp_cert_multi[type.to_s]
+          next if !certs_for_type || certs_for_type.empty?
+
+          unless certs_for_type.is_a?(Array) && certs_for_type.all? { |cert| cert.is_a?(Hash) }
+            raise ArgumentError.new("sp_cert_multi :#{type} node must be an Array of Hashes")
+          end
+
+          certs_for_type.each do |pair|
+            cert = pair[:certificate] || pair['certificate'] || pair[:cert] || pair['cert']
+            key  = pair[:private_key] || pair['private_key'] || pair[:key] || pair['key']
+
+            unless cert && key
+              raise ArgumentError.new("sp_cert_multi :#{type} node Hashes must specify keys :certificate and :private_key")
+            end
+
+            certs[type] << [
+              OneLogin::RubySaml::Utils.build_cert_object(cert),
+              OneLogin::RubySaml::Utils.build_private_key_object(key)
+            ].freeze
+          end
+        end
+
+        certs.each { |_, ary| ary.freeze }
+        certs
+      end
     end
   end
 end
+

--- a/lib/onelogin/ruby-saml/slo_logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutrequest.rb
@@ -91,16 +91,16 @@ module OneLogin
       end
 
       # Decrypts an EncryptedID element
-      # @param encryptedid_node [REXML::Element] The EncryptedID element
+      # @param encrypted_id_node [REXML::Element] The EncryptedID element
       # @return [REXML::Document] The decrypted EncrypedtID element
       #
-      def decrypt_nameid(encrypt_node)
+      def decrypt_nameid(encrypted_id_node)
 
-        if settings.nil? || !settings.get_sp_key
-          raise ValidationError.new('An ' + encrypt_node.name + ' found and no SP private key found on the settings to decrypt it')
+        if settings.nil? || settings.get_sp_decryption_keys.empty?
+          raise ValidationError.new('An ' + encrypted_id_node.name + ' found and no SP private key found on the settings to decrypt it')
         end
 
-        elem_plaintext = OneLogin::RubySaml::Utils.decrypt_data(encrypt_node, settings.get_sp_key)
+        elem_plaintext = OneLogin::RubySaml::Utils.decrypt_multi(encrypted_id_node, settings.get_sp_decryption_keys)
         # If we get some problematic noise in the plaintext after decrypting.
         # This quick regexp parse will grab only the Element and discard the noise.
         elem_plaintext = elem_plaintext.match(/(.*<\/(\w+:)?NameID>)/m)[0]

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -34,16 +34,24 @@ module OneLogin
       $)x.freeze
       UUID_PREFIX = '_'
 
-      # Checks if the x509 cert provided is expired
+      # Checks if the x509 cert provided is expired.
       #
-      # @param cert [Certificate] The x509 certificate
-      #
+      # @param cert [OpenSSL::X509::Certificate|String] The x509 certificate.
+      # @return [true|false] Whether the certificate is expired.
       def self.is_cert_expired(cert)
-        if cert.is_a?(String)
-          cert = OpenSSL::X509::Certificate.new(cert)
-        end
+        cert = OpenSSL::X509::Certificate.new(cert) if cert.is_a?(String)
 
-        return cert.not_after < Time.now
+        cert.not_after < Time.now
+      end
+
+      # Checks if the x509 cert provided has both started and has not expired.
+      #
+      # @param cert [OpenSSL::X509::Certificate|String] The x509 certificate.
+      # @return [true|false] Whether the certificate is currently active.
+      def self.is_cert_active(cert)
+        cert = OpenSSL::X509::Certificate.new(cert) if cert.is_a?(String)
+        now = Time.now
+        cert.not_before <= now && cert.not_after >= now
       end
 
       # Interprets a ISO8601 duration value relative to a given timestamp.
@@ -128,6 +136,28 @@ module OneLogin
         "-----BEGIN #{key_label}-----\n#{key}\n-----END #{key_label}-----"
       end
 
+      # Given a certificate string, return an OpenSSL::X509::Certificate object.
+      #
+      # @param cert [String] The original certificate
+      # @return [OpenSSL::X509::Certificate] The certificate object
+      #
+      def self.build_cert_object(cert)
+        return nil if cert.nil? || cert.empty?
+
+        OpenSSL::X509::Certificate.new(format_cert(cert))
+      end
+
+      # Given a private key string, return an OpenSSL::PKey::RSA object.
+      #
+      # @param cert [String] The original private key
+      # @return [OpenSSL::PKey::RSA] The private key object
+      #
+      def self.build_private_key_object(private_key)
+        return nil if private_key.nil? || private_key.empty?
+
+        OpenSSL::PKey::RSA.new(format_private_key(private_key))
+      end
+
       # Build the Query String signature that will be used in the HTTP-Redirect binding
       # to generate the Signature
       # @param params [Hash] Parameters to build the Query String
@@ -199,7 +229,7 @@ module OneLogin
 
       # Validate the Signature parameter sent on the HTTP-Redirect binding
       # @param params [Hash] Parameters to be used in the validation process
-      # @option params [OpenSSL::X509::Certificate] cert The Identity provider public certtificate
+      # @option params [OpenSSL::X509::Certificate] cert The IDP public certificate
       # @option params [String] sig_alg The SigAlg parameter
       # @option params [String] signature The Signature parameter (base64 encoded)
       # @option params [String] query_string The full GET Query String to be compared
@@ -236,9 +266,29 @@ module OneLogin
         error_msg
       end
 
+      # Obtains the decrypted string from an Encrypted node element in XML,
+      # given multiple private keys to try.
+      # @param encrypted_node [REXML::Element] The Encrypted element
+      # @param private_keys [Array<OpenSSL::PKey::RSA>] The Service provider private key
+      # @return [String] The decrypted data
+      def self.decrypt_multi(encrypted_node, private_keys)
+        raise ArgumentError.new('private_keys must be specified') if !private_keys || private_keys.empty?
+
+        error = nil
+        private_keys.each do |key|
+          begin
+            return decrypt_data(encrypted_node, key)
+          rescue OpenSSL::PKey::PKeyError => e
+            error ||= e
+          end
+        end
+
+        raise(error) if error
+      end
+
       # Obtains the decrypted string from an Encrypted node element in XML
-      # @param encrypted_node [REXML::Element]     The Encrypted element
-      # @param private_key    [OpenSSL::PKey::RSA] The Service provider private key
+      # @param encrypted_node [REXML::Element] The Encrypted element
+      # @param private_key [OpenSSL::PKey::RSA] The Service provider private key
       # @return [String] The decrypted data
       def self.decrypt_data(encrypted_node, private_key)
         encrypt_data = REXML::XPath.first(
@@ -302,7 +352,7 @@ module OneLogin
 
       # Obtains the deciphered text
       # @param cipher_text [String]   The ciphered text
-      # @param symmetric_key [String] The symetric key used to encrypt the text
+      # @param symmetric_key [String] The symmetric key used to encrypt the text
       # @param algorithm [String]     The encrypted algorithm
       # @return [String] The deciphered text
       def self.retrieve_plaintext(cipher_text, symmetric_key, algorithm)

--- a/test/helpers/certificate_helper.rb
+++ b/test/helpers/certificate_helper.rb
@@ -1,0 +1,44 @@
+require 'openssl'
+
+module CertificateHelper
+  extend self
+
+  def generate_pair(not_before: nil, not_after: nil)
+    key = generate_key
+    cert = generate_cert(key, not_before: not_before, not_after: not_after)
+    [cert, key]
+  end
+
+  def generate_pair_hash(not_before: nil, not_after: nil)
+    cert, key = generate_pair(not_before: not_before, not_after: not_after)
+    { certificate: cert.to_pem, private_key: key.to_pem }
+  end
+
+  def generate_key
+    OpenSSL::PKey::RSA.new(1024)
+  end
+
+  def generate_cert(key = generate_key, not_before: nil, not_after: nil)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 0
+    cert.not_before = not_before || Time.now - one_year
+    cert.not_after  = not_after  || Time.now + one_year
+    cert.public_key = key.public_key
+    cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=ruby-saml/CN=Ruby SAML CA"
+    cert.issuer = cert.subject # self-signed
+    factory = OpenSSL::X509::ExtensionFactory.new
+    factory.subject_certificate = cert
+    factory.issuer_certificate = cert
+    cert.add_extension factory.create_extension("basicConstraints","CA:TRUE", true)
+    cert.add_extension factory.create_extension("keyUsage","keyCertSign, cRLSign", true)
+    cert.sign(key, OpenSSL::Digest::SHA1.new)
+    cert
+  end
+
+  private
+
+  def one_year
+    3600 * 24 * 365
+  end
+end

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -110,7 +110,6 @@ class RequestTest < Minitest::Test
     end
 
     describe "signing with HTTP-POST binding" do
-
       before do
         settings.security[:logout_requests_signed] = true
         settings.idp_slo_service_binding = :post
@@ -153,7 +152,7 @@ class RequestTest < Minitest::Test
         assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2000/09/xmldsig#sha1'/>], inflated
       end
 
-      it "created a signed logout request" do
+      it "create a signed logout request" do
         settings.compress_request = true
 
         unauth_req = OneLogin::RubySaml::Logoutrequest.new
@@ -165,6 +164,17 @@ class RequestTest < Minitest::Test
         assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2000/09/xmldsig#sha1'/>], inflated
       end
 
+      it "create an uncompressed signed logout request" do
+        settings.compress_request = false
+
+        params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
+        request_xml = Base64.decode64(params["SAMLRequest"])
+
+        assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], request_xml
+        assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2000/09/xmldsig#sha1'/>], request_xml
+      end
+
       it "create a signed logout request with 256 digest and signature method" do
         settings.compress_request = false
         settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
@@ -172,7 +182,6 @@ class RequestTest < Minitest::Test
 
         params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
         request_xml = Base64.decode64(params["SAMLRequest"])
-
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
         assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'/>], request_xml
         assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2001/04/xmlenc#sha256'/>], request_xml
@@ -189,6 +198,53 @@ class RequestTest < Minitest::Test
         assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
         assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'/>], request_xml
         assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2001/04/xmlenc#sha512'/>], request_xml
+      end
+
+      it "create a signed logout request using the first certificate and key" do
+        settings.compress_request = false
+        settings.certificate = nil
+        settings.private_key = nil
+        settings.sp_cert_multi = {
+          signing: [
+            { certificate: ruby_saml_cert_text, private_key: ruby_saml_key_text },
+            CertificateHelper.generate_pair_hash
+          ]
+        }
+
+        params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
+        request_xml = Base64.decode64(params["SAMLRequest"])
+
+        assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], request_xml
+        assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2000/09/xmldsig#sha1'/>], request_xml
+      end
+
+      it "create a signed logout request using the first valid certificate and key when :check_sp_cert_expiration is true" do
+        settings.compress_request = false
+        settings.certificate = nil
+        settings.private_key = nil
+        settings.security[:check_sp_cert_expiration] = true
+        settings.sp_cert_multi = {
+          signing: [
+            { certificate: ruby_saml_cert_text, private_key: ruby_saml_key_text },
+            CertificateHelper.generate_pair_hash
+          ]
+        }
+
+        params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
+        request_xml = Base64.decode64(params["SAMLRequest"])
+
+        assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], request_xml
+        assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2000/09/xmldsig#sha1'/>], request_xml
+      end
+
+      it "raises error when no valid certs and :check_sp_cert_expiration is true" do
+        settings.security[:check_sp_cert_expiration] = true
+
+        assert_raises(OneLogin::RubySaml::ValidationError, 'The SP certificate expired.') do
+          OneLogin::RubySaml::Logoutrequest.new.create_params(settings)
+        end
       end
     end
 
@@ -268,6 +324,41 @@ class RequestTest < Minitest::Test
         signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA512
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
+      end
+
+      it "create a signature parameter using the first certificate and key" do
+        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
+        settings.compress_request = false
+        settings.certificate = nil
+        settings.private_key = nil
+        settings.sp_cert_multi = {
+          signing: [
+            { certificate: ruby_saml_cert_text, private_key: ruby_saml_key_text },
+            CertificateHelper.generate_pair_hash
+          ]
+        }
+
+        params = OneLogin::RubySaml::Logoutrequest.new.create_params(settings, :RelayState => 'http://example.com')
+        assert params['SAMLRequest']
+        assert params[:RelayState]
+        assert params['Signature']
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
+
+        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
+        query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
+
+        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        assert_equal signature_algorithm, OpenSSL::Digest::SHA1
+        assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
+      end
+
+      it "raises error when no valid certs and :check_sp_cert_expiration is true" do
+        settings.security[:check_sp_cert_expiration] = true
+
+        assert_raises(OneLogin::RubySaml::ValidationError, 'The SP certificate expired.') do
+          OneLogin::RubySaml::Logoutrequest.new.create_params(settings, :RelayState => 'http://example.com')
+        end
       end
     end
 

--- a/test/logoutresponse_test.rb
+++ b/test/logoutresponse_test.rb
@@ -315,7 +315,7 @@ class RubySamlTest < Minitest::Test
           assert_equal(CGI.unescape(query), CGI.unescape(original_query))
           # Make normalised signature based on our modified params.
           sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
-          signature = settings.get_sp_key.sign(sign_algorithm.new, query)
+          signature = settings.get_sp_signing_key.sign(sign_algorithm.new, query)
           params['Signature'] = Base64.encode64(signature).gsub(/\n/, "")
           # Re-create the Logoutresponse based on these modified parameters,
           # and ask it to validate the signature. It will do it incorrectly,
@@ -351,7 +351,7 @@ class RubySamlTest < Minitest::Test
           assert_equal(CGI.unescape(query), CGI.unescape(original_query))
           # Make normalised signature based on our modified params.
           sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
-          signature = settings.get_sp_key.sign(sign_algorithm.new, query)
+          signature = settings.get_sp_signing_key.sign(sign_algorithm.new, query)
           params['Signature'] = Base64.encode64(signature).gsub(/\n/, "")
           # Re-create the Logoutresponse based on these modified parameters,
           # and ask it to validate the signature. Provide the altered parameter

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -268,6 +268,49 @@ class RequestTest < Minitest::Test
         assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'/>], request_xml
         assert_match %r[<ds:DigestMethod Algorithm='http://www.w3.org/2001/04/xmlenc#sha512'/>], request_xml
       end
+
+      it "creates a signed request using the first certificate and key" do
+        settings.certificate = nil
+        settings.private_key = nil
+        settings.sp_cert_multi = {
+          signing: [
+            { certificate: ruby_saml_cert_text, private_key: ruby_saml_key_text },
+            CertificateHelper.generate_pair_hash
+          ]
+        }
+
+        params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
+
+        request_xml = Base64.decode64(params["SAMLRequest"])
+        assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], request_xml
+      end
+
+      it "creates a signed request using the first valid certificate and key when :check_sp_cert_expiration is true" do
+        settings.certificate = nil
+        settings.private_key = nil
+        settings.security[:check_sp_cert_expiration] = true
+        settings.sp_cert_multi = {
+          signing: [
+            { certificate: ruby_saml_cert_text, private_key: ruby_saml_key_text },
+            CertificateHelper.generate_pair_hash
+          ]
+        }
+
+        params = OneLogin::RubySaml::Authrequest.new.create_params(settings)
+
+        request_xml = Base64.decode64(params["SAMLRequest"])
+        assert_match %r[<ds:SignatureValue>([a-zA-Z0-9/+=]+)</ds:SignatureValue>], request_xml
+        assert_match %r[<ds:SignatureMethod Algorithm='http://www.w3.org/2000/09/xmldsig#rsa-sha1'/>], request_xml
+      end
+
+      it "raises error when no valid certs and :check_sp_cert_expiration is true" do
+        settings.security[:check_sp_cert_expiration] = true
+
+        assert_raises(OneLogin::RubySaml::ValidationError, 'The SP certificate expired.') do
+          OneLogin::RubySaml::Authrequest.new.create_params(settings)
+        end
+      end
     end
 
     describe "#create_params signing with HTTP-Redirect binding" do
@@ -298,7 +341,6 @@ class RequestTest < Minitest::Test
 
         signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
-
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
 
@@ -316,6 +358,41 @@ class RequestTest < Minitest::Test
         signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA256
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
+      end
+
+      it "create a signature parameter using the first certificate and key" do
+        settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA1
+        settings.compress_request = false
+        settings.certificate = nil
+        settings.private_key = nil
+        settings.sp_cert_multi = {
+          signing: [
+            { certificate: ruby_saml_cert_text, private_key: ruby_saml_key_text },
+            CertificateHelper.generate_pair_hash
+          ]
+        }
+
+        params = OneLogin::RubySaml::Authrequest.new.create_params(settings, :RelayState => 'http://example.com')
+        assert params['SAMLRequest']
+        assert params[:RelayState]
+        assert params['Signature']
+        assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
+
+        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
+        query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
+
+        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        assert_equal signature_algorithm, OpenSSL::Digest::SHA1
+        assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
+      end
+
+      it "raises error when no valid certs and :check_sp_cert_expiration is true" do
+        settings.security[:check_sp_cert_expiration] = true
+
+        assert_raises(OneLogin::RubySaml::ValidationError, 'The SP certificate expired.') do
+          OneLogin::RubySaml::Authrequest.new.create_params(settings, :RelayState => 'http://example.com')
+        end
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ require 'bundler'
 require 'minitest/autorun'
 require 'mocha/setup'
 require 'timecop'
+Dir[File.expand_path('../helpers/**/*.rb', __FILE__)].each { |f| require f }
 
 Bundler.require :default, :test
 

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -88,7 +88,6 @@ class UtilsTest < Minitest::Test
       invalid_chained_certificate1 = read_certificate("invalid_chained_certificate1")
       assert_equal formatted_chained_certificate, OneLogin::RubySaml::Utils.format_cert(invalid_chained_certificate1)
     end
-
   end
 
   describe ".format_private_key" do
@@ -151,7 +150,49 @@ class UtilsTest < Minitest::Test
     end
   end
 
-  describe "build_query" do
+  describe '.build_cert_object' do
+    it 'returns a certificate object for valid certificate string' do
+      cert_object = OneLogin::RubySaml::Utils.build_cert_object(ruby_saml_cert_text)
+      assert_instance_of OpenSSL::X509::Certificate, cert_object
+    end
+
+    it 'returns nil for nil certificate string' do
+      assert_nil OneLogin::RubySaml::Utils.build_cert_object(nil)
+    end
+
+    it 'returns nil for empty certificate string' do
+      assert_nil OneLogin::RubySaml::Utils.build_cert_object('')
+    end
+
+    it 'raises error when given an invalid certificate string' do
+      assert_raises OpenSSL::X509::CertificateError do
+        OneLogin::RubySaml::Utils.build_cert_object('Foobar')
+      end
+    end
+  end
+
+  describe '.build_private_key_object' do
+    it 'returns a private key object for valid private key string' do
+      private_key_object = OneLogin::RubySaml::Utils.build_private_key_object(ruby_saml_key_text)
+      assert_instance_of OpenSSL::PKey::RSA, private_key_object
+    end
+
+    it 'returns nil for nil private key string' do
+      assert_nil OneLogin::RubySaml::Utils.build_private_key_object(nil)
+    end
+
+    it 'returns nil for empty private key string' do
+      assert_nil OneLogin::RubySaml::Utils.build_private_key_object('')
+    end
+
+    it 'raises error when given an invalid private key string' do
+      assert_raises OpenSSL::PKey::RSAError do
+        OneLogin::RubySaml::Utils.build_private_key_object('Foobar')
+      end
+    end
+  end
+
+  describe ".build_query" do
     it "returns the query string" do
       params = {}
       params[:type] = "SAMLRequest"
@@ -163,7 +204,7 @@ class UtilsTest < Minitest::Test
     end
   end
 
-  describe "#verify_signature" do
+  describe ".verify_signature" do
     before do
       @params = {}
       @params[:cert] = ruby_saml_cert
@@ -182,7 +223,7 @@ class UtilsTest < Minitest::Test
     end
   end
 
-  describe "#status_error_msg" do
+  describe ".status_error_msg" do
     it "returns a error msg with status_code and status message" do
       error_msg = "The status code of the Logout Response was not Success"
       status_code = "urn:oasis:names:tc:SAML:2.0:status:Requester"
@@ -217,7 +258,7 @@ class UtilsTest < Minitest::Test
       end
     end
 
-    describe 'uri_match' do
+    describe '.uri_match?' do
       it 'matches two urls' do
         destination = 'http://www.example.com/test?var=stuff'
         settings = 'http://www.example.com/test?var=stuff'
@@ -267,7 +308,7 @@ class UtilsTest < Minitest::Test
       end
     end
 
-    describe 'element_text' do
+    describe '.element_text' do
       it 'returns the element text' do
         element = REXML::Document.new('<element>element text</element>').elements.first
         assert_equal 'element text', OneLogin::RubySaml::Utils.element_text(element)
@@ -301,7 +342,117 @@ class UtilsTest < Minitest::Test
         element = REXML::Document.new('<element></element>').elements.first
         assert_equal '', OneLogin::RubySaml::Utils.element_text(element)
       end
+    end
+  end
 
+  describe '.decrypt_multi' do
+    let(:private_key) { ruby_saml_key }
+    let(:invalid_key1) { CertificateHelper.generate_key }
+    let(:invalid_key2) { CertificateHelper.generate_key }
+    let(:settings) { OneLogin::RubySaml::Settings.new(:private_key => private_key.to_pem) }
+    let(:response) { OneLogin::RubySaml::Response.new(signed_message_encrypted_unsigned_assertion, :settings => settings) }
+    let(:encrypted) do
+      REXML::XPath.first(
+        response.document,
+        "(/p:Response/EncryptedAssertion/)|(/p:Response/a:EncryptedAssertion/)",
+        { "p" => "urn:oasis:names:tc:SAML:2.0:protocol", "a" => "urn:oasis:names:tc:SAML:2.0:assertion" }
+      )
+    end
+
+    it 'successfully decrypts with the first private key' do
+      assert_match /\A<saml:Assertion/, OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [private_key])
+    end
+
+    it 'successfully decrypts with a subsequent private key' do
+      assert_match /\A<saml:Assertion/, OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [invalid_key1, private_key])
+    end
+
+    it 'raises an error when there is only one key and it fails to decrypt' do
+      assert_raises OpenSSL::PKey::PKeyError do
+        OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [invalid_key1])
+      end
+    end
+
+    it 'raises an error when all keys fail to decrypt' do
+      assert_raises OpenSSL::PKey::PKeyError do
+        OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [invalid_key1, invalid_key2])
+      end
+    end
+
+    it 'raises an error when private keys is an empty array' do
+      assert_raises ArgumentError do
+        OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [])
+      end
+    end
+
+    it 'raises an error when private keys is nil' do
+      assert_raises ArgumentError do
+        OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [])
+      end
+    end
+  end
+
+  describe '.is_cert_expired' do
+    it 'returns true for expired certificate' do
+      expired_cert = CertificateHelper.generate_cert(not_after: Time.now - 60)
+      assert OneLogin::RubySaml::Utils.is_cert_expired(expired_cert)
+    end
+
+    it 'returns false for not-started certificate' do
+      not_started_cert = CertificateHelper.generate_cert(not_before: Time.now + 60)
+      refute OneLogin::RubySaml::Utils.is_cert_active(not_started_cert)
+    end
+
+    it 'returns false for active certificate' do
+      valid_cert = CertificateHelper.generate_cert
+      refute OneLogin::RubySaml::Utils.is_cert_expired(valid_cert)
+    end
+
+    it 'returns true for expired certificate string' do
+      expired_cert_string = CertificateHelper.generate_cert(not_after: Time.now - 60).to_pem
+      assert OneLogin::RubySaml::Utils.is_cert_expired(expired_cert_string)
+    end
+
+    it 'returns false for not-started certificate string' do
+      not_started_cert_string = CertificateHelper.generate_cert(not_before: Time.now + 60).to_pem
+      refute OneLogin::RubySaml::Utils.is_cert_active(not_started_cert_string)
+    end
+
+    it 'returns false for active certificate string' do
+      valid_cert_string = CertificateHelper.generate_cert.to_pem
+      refute OneLogin::RubySaml::Utils.is_cert_expired(valid_cert_string)
+    end
+  end
+
+  describe '.is_cert_active' do
+    it 'returns true for active certificate' do
+      valid_cert = CertificateHelper.generate_cert
+      assert OneLogin::RubySaml::Utils.is_cert_active(valid_cert)
+    end
+
+    it 'returns false for not-started certificate' do
+      not_started_cert = CertificateHelper.generate_cert(not_before: Time.now + 60)
+      refute OneLogin::RubySaml::Utils.is_cert_active(not_started_cert)
+    end
+
+    it 'returns false for expired certificate' do
+      expired_cert = CertificateHelper.generate_cert(not_after: Time.now - 60)
+      refute OneLogin::RubySaml::Utils.is_cert_active(expired_cert)
+    end
+
+    it 'returns true for active certificate string' do
+      valid_cert_string = CertificateHelper.generate_cert.to_pem
+      assert OneLogin::RubySaml::Utils.is_cert_active(valid_cert_string)
+    end
+
+    it 'returns false for not-started certificate string' do
+      not_started_cert_string = CertificateHelper.generate_cert(not_before: Time.now + 60).to_pem
+      refute OneLogin::RubySaml::Utils.is_cert_active(not_started_cert_string)
+    end
+
+    it 'returns false for expired certificate string' do
+      expired_cert_string = CertificateHelper.generate_cert(not_after: Time.now - 60).to_pem
+      refute OneLogin::RubySaml::Utils.is_cert_active(expired_cert_string)
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/SAML-Toolkits/ruby-saml/issues/560

This PR introduces `sp_cert_multi` parameter which is analogous to `idp_cert_multi`. It allows developers to have fine-grained control over SP certs and private keys, including:
1. Allow SP to have separate SP signing and encryption keys (required by some governmental regulations.)
2. Allow SP to rotate SP private keys, not just certificates (for example, if key becomes compromised.)
3. Allow SP to have more than two concurrent pairs of SP certs/keys in rotation at once.

The changes are summarized as follows:
1. Add `SamlSettings sp_cert_multi` parameter. It has the following shape:

   ```ruby
   sp_cert_multi = {
     signing: [
       { certificate: cert1, private_key: private_key1 },
       { certificate: cert2, private_key: private_key2 }
     ],
     encryption: [
       { certificate: cert1, private_key: private_key1 },
       { certificate: cert3, private_key: private_key3 }
     ],
   }
   ```
   *(Note: You can use same certs for signing/encryption, and same PK everywhere. It's completely backward compatible with current functionality.)*

2. `sp_cert_multi` is mutually exclusive with the following: `certificate, certificate_new, private_key`.
3. If `security[:check_sp_cert_expiry]` is true, Ruby Saml automatically uses the first **non-expired** certificate in `sp_cert_multi[:signing]` for signing, and only uses private keys associated with non-expired certs in `sp_cert_multi[:encryption]` for decryption. This is evaluated in realtime, so as soon as your old cert expires your app automatically starts signing with the new one.
4. The validation error `:check_sp_cert_expiration` is now raised only if **ALL** SP certs are expired. This is a slight behavior change; 
   * **Previously** if `Settings.certificate` was expired but `Settings.certificate_new` was not, an error would be raised.
   * **In this PR** this case does not raise an error and starts automatically using `certificate_new` for signing. (This case was not previously in the tests, but I've now added a test for it with the new logic.)
5. `:check_sp_cert_expiration` now also validates the certificate `not_before` condition; previously it was only validating `not_after`.
   * I did **not** add it in this PR, but we should also do the same thing for IdP certs--see here: https://github.com/SAML-Toolkits/ruby-saml/issues/674)
6. If `:check_sp_cert_expiration` is true, we now no longer include expired certs in the generated SP metadata. This is a good practice because having expired certs may cause the IdP system to throw an error, depending on how strictly it does its validation.
   * Point of discussion: It's debatable if we want to include "not_before" certs here (i.e. not yet ready to use, but ok for IdP to pre-cache and use when ready.) For simplicity's sake I've excluded them, especially because "not_before" is relatively rare in the wild.
8. Refactor so that internal references to `get_sp_cert`, `get_sp_private_key`, etc. now point to the new structure of multiple certs.
9. When performing decryption, we now try all private keys under `sp_cert_multi[:encryption]` (this is analogous to how we try all IDP certs in `idp_cert_multi[:signing]` when verifiying the IDP signature.)
10. Extract out `OneLogin::RubySaml::Utils.build_cert_object` and `build_private_key_object`.
11. Deprecate the `certificate_new` parameter since `sp_cert_multi` fulfills the same role better. It still works but it is removed from the docs.
12. When there are multiple SP certs, the ordering of SP KeyDescriptor node in the SP metadata XML will now be all signing keys first, and then all encryption keys. (Previously it would be signing, encryption, signing, encryption.) This does not affect XML integrity in any way.
13. This PR contains unit tests and integration tests for all major SP signing flows (both Redirect and POST). Decryption is covered as well.