### PR TITLE
Allow passing in timeout/retry settings to Net::HTTP

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -54,11 +54,6 @@ module OneLogin
       # @param url [String] Url where the XML of the Identity Provider Metadata is published.
       # @param validate_cert [Boolean] If true and the URL is HTTPs, the cert of the domain is checked.
       #
-      # @param request_options [Hash] options used for requesting the remote URL
-      # @option request_options [Numeric, nil] :open_timeout Number of seconds to wait for the connection to open. See Net::HTTP#open_timeout for more info. Default is the Net::HTTP default.
-      # @option request_options [Numeric, nil] :read_timeout Number of seconds to wait for one block to be read. See Net::HTTP#read_timeout for more info. Default is the Net::HTTP default.
-      # @option request_options [Integer, nil] :max_retries Maximum number of times to retry the request on certain errors. See Net::HTTP#max_retries= for more info. Default is the Net::HTTP default.
-      #
       # @param options [Hash] options used for parsing the metadata and the returned Settings instance
       # @option options [OneLogin::RubySaml::Settings, Hash] :settings the OneLogin::RubySaml::Settings object which gets the parsed metadata merged into or an hash for Settings overrides.
       # @option options [String, nil] :entity_id when this is given, the entity descriptor for this ID is used. When omitted, the first entity descriptor is used.
@@ -66,10 +61,15 @@ module OneLogin
       # @option options [String, Array<String>, nil] :slo_binding an ordered list of bindings to detect the single logout URL. The first binding in the list that is included in the metadata will be used.
       # @option options [String, Array<String>, nil] :name_id_format an ordered list of NameIDFormats to detect a desired value. The first NameIDFormat in the list that is included in the metadata will be used.
       #
+      # @param request_options [Hash] options used for requesting the remote URL
+      # @option request_options [Numeric, nil] :open_timeout Number of seconds to wait for the connection to open. See Net::HTTP#open_timeout for more info. Default is the Net::HTTP default.
+      # @option request_options [Numeric, nil] :read_timeout Number of seconds to wait for one block to be read. See Net::HTTP#read_timeout for more info. Default is the Net::HTTP default.
+      # @option request_options [Integer, nil] :max_retries Maximum number of times to retry the request on certain errors. See Net::HTTP#max_retries= for more info. Default is the Net::HTTP default.
+      #
       # @return [OneLogin::RubySaml::Settings]
       #
       # @raise [HttpError] Failure to fetch remote IdP metadata
-      def parse_remote(url, validate_cert = true, request_options = {}, options = {})
+      def parse_remote(url, validate_cert = true, options = {}, request_options = {})
         idp_metadata = get_idp_metadata(url, validate_cert, request_options)
         parse(idp_metadata, options)
       end
@@ -79,21 +79,21 @@ module OneLogin
       # @param url [String] Url where the XML of the Identity Provider Metadata is published.
       # @param validate_cert [Boolean] If true and the URL is HTTPs, the cert of the domain is checked.
       #
-      # @param request_options [Hash] options used for requesting the remote URL
-      # @option request_options [Numeric, nil] :open_timeout Number of seconds to wait for the connection to open. See Net::HTTP#open_timeout for more info. Default is the Net::HTTP default.
-      # @option request_options [Numeric, nil] :read_timeout Number of seconds to wait for one block to be read. See Net::HTTP#read_timeout for more info. Default is the Net::HTTP default.
-      # @option request_options [Integer, nil] :max_retries Maximum number of times to retry the request on certain errors. See Net::HTTP#max_retries= for more info. Default is the Net::HTTP default.
-      #
       # @param options [Hash] options used for parsing the metadata
       # @option options [String, nil] :entity_id when this is given, the entity descriptor for this ID is used. When omitted, the first entity descriptor is used.
       # @option options [String, Array<String>, nil] :sso_binding an ordered list of bindings to detect the single signon URL. The first binding in the list that is included in the metadata will be used.
       # @option options [String, Array<String>, nil] :slo_binding an ordered list of bindings to detect the single logout URL. The first binding in the list that is included in the metadata will be used.
       # @option options [String, Array<String>, nil] :name_id_format an ordered list of NameIDFormats to detect a desired value. The first NameIDFormat in the list that is included in the metadata will be used.
       #
+      # @param request_options [Hash] options used for requesting the remote URL
+      # @option request_options [Numeric, nil] :open_timeout Number of seconds to wait for the connection to open. See Net::HTTP#open_timeout for more info. Default is the Net::HTTP default.
+      # @option request_options [Numeric, nil] :read_timeout Number of seconds to wait for one block to be read. See Net::HTTP#read_timeout for more info. Default is the Net::HTTP default.
+      # @option request_options [Integer, nil] :max_retries Maximum number of times to retry the request on certain errors. See Net::HTTP#max_retries= for more info. Default is the Net::HTTP default.
+      #
       # @return [Hash]
       #
       # @raise [HttpError] Failure to fetch remote IdP metadata
-      def parse_remote_to_hash(url, validate_cert = true, request_options = {}, options = {})
+      def parse_remote_to_hash(url, validate_cert = true, options = {}, request_options = {})
         parse_remote_to_array(url, validate_cert, request_options, options)[0]
       end
 
@@ -102,21 +102,21 @@ module OneLogin
       # @param url [String] Url where the XML of the Identity Provider Metadata is published.
       # @param validate_cert [Boolean] If true and the URL is HTTPs, the cert of the domain is checked.
       #
-      # @param request_options [Hash] options used for requesting the remote URL
-      # @option request_options [Numeric, nil] :open_timeout Number of seconds to wait for the connection to open. See Net::HTTP#open_timeout for more info. Default is the Net::HTTP default.
-      # @option request_options [Numeric, nil] :read_timeout Number of seconds to wait for one block to be read. See Net::HTTP#read_timeout for more info. Default is the Net::HTTP default.
-      # @option request_options [Integer, nil] :max_retries Maximum number of times to retry the request on certain errors. See Net::HTTP#max_retries= for more info. Default is the Net::HTTP default.
-      #
       # @param options [Hash] options used for parsing the metadata
       # @option options [String, nil] :entity_id when this is given, the entity descriptor for this ID is used. When omitted, all found IdPs are returned.
       # @option options [String, Array<String>, nil] :sso_binding an ordered list of bindings to detect the single signon URL. The first binding in the list that is included in the metadata will be used.
       # @option options [String, Array<String>, nil] :slo_binding an ordered list of bindings to detect the single logout URL. The first binding in the list that is included in the metadata will be used.
       # @option options [String, Array<String>, nil] :name_id_format an ordered list of NameIDFormats to detect a desired value. The first NameIDFormat in the list that is included in the metadata will be used.
       #
+      # @param request_options [Hash] options used for requesting the remote URL
+      # @option request_options [Numeric, nil] :open_timeout Number of seconds to wait for the connection to open. See Net::HTTP#open_timeout for more info. Default is the Net::HTTP default.
+      # @option request_options [Numeric, nil] :read_timeout Number of seconds to wait for one block to be read. See Net::HTTP#read_timeout for more info. Default is the Net::HTTP default.
+      # @option request_options [Integer, nil] :max_retries Maximum number of times to retry the request on certain errors. See Net::HTTP#max_retries= for more info. Default is the Net::HTTP default.
+      #
       # @return [Array<Hash>]
       #
       # @raise [HttpError] Failure to fetch remote IdP metadata
-      def parse_remote_to_array(url, validate_cert = true, request_options = {}, options = {})
+      def parse_remote_to_array(url, validate_cert = true, options = {}, request_options = {})
         idp_metadata = get_idp_metadata(url, validate_cert, request_options)
         parse_to_array(idp_metadata, options)
       end

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -342,7 +342,7 @@ class IdpMetadataParserTest < Minitest::Test
       refute_equal 4, @http.max_retries
 
       idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
-      settings = idp_metadata_parser.parse_remote(@url, true, open_timeout: 2, read_timeout: 3, max_retries: 4)
+      settings = idp_metadata_parser.parse_remote(@url, true, {}, open_timeout: 2, read_timeout: 3, max_retries: 4)
 
       assert_equal 2, @http.open_timeout
       assert_equal 3, @http.read_timeout

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -335,6 +335,19 @@ class IdpMetadataParserTest < Minitest::Test
 
       assert_equal OpenSSL::SSL::VERIFY_NONE, @http.verify_mode
     end
+
+    it "allows setting HTTP options on the request" do
+      refute_equal 2, @http.open_timeout
+      refute_equal 3, @http.read_timeout
+      refute_equal 4, @http.max_retries
+
+      idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+      settings = idp_metadata_parser.parse_remote(@url, true, open_timeout: 2, read_timeout: 3, max_retries: 4)
+
+      assert_equal 2, @http.open_timeout
+      assert_equal 3, @http.read_timeout
+      assert_equal 4, @http.max_retries
+    end
   end
 
   describe "download and parse IdP descriptor file into an Hash" do


### PR DESCRIPTION
When fetching remote XML files from arbitrary URLs, you might want to configure different values for timeouts/retries to avoid allowing users to DoS you via intentionally slow endpoints.  The Net::HTTP defaults are 60 seconds plus 1 retry, which could easily deplete resources if intentionally exploited.