### PR TITLE
Make the gem compatible with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest]
-        ruby-version: [2.1.9, 2.2.10, 2.3.8, 2.4.6, 2.5.8, 2.6.6, 2.7.2, 3.0.1, 3.1, 3.2, jruby-9.1.17.0, jruby-9.2.17.0, jruby-9.3.2.0, jruby-9.4.0.0, truffleruby]
+        ruby-version: [2.1.9, 2.2.10, 2.3.8, 2.4.6, 2.5.8, 2.6.6, 2.7.2, 3.0.1, 3.1, 3.2, 3.3, jruby-9.1.17.0, jruby-9.2.17.0, jruby-9.3.2.0, jruby-9.4.0.0, truffleruby]
+        ruby-opt: [""]
+        include:
+          - os: "ubuntu-20.04"
+            ruby-version: 3.3
+            ruby-opt: "--enable-frozen-string-literal --debug-frozen-string-literal"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -21,8 +26,8 @@ jobs:
       - name: Install dependencies
         run: bundle install
 
-      - name: Run tests
-        run: bundle exec rake
+      - name: Run tests ${{ matrix.ruby-opt }}
+        run: bundle exec rake RUBYOPT="${{ matrix.ruby-opt }}"
 
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,6 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-latest]
         ruby-version: [2.1.9, 2.2.10, 2.3.8, 2.4.6, 2.5.8, 2.6.6, 2.7.2, 3.0.1, 3.1, 3.2, 3.3, jruby-9.1.17.0, jruby-9.2.17.0, jruby-9.3.2.0, jruby-9.4.0.0, truffleruby]
-        ruby-opt: [""]
-        include:
-          - os: "ubuntu-20.04"
-            ruby-version: 3.3
-            ruby-opt: "--enable-frozen-string-literal --debug-frozen-string-literal"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -26,8 +21,8 @@ jobs:
       - name: Install dependencies
         run: bundle install
 
-      - name: Run tests ${{ matrix.ruby-opt }}
-        run: bundle exec rake RUBYOPT="${{ matrix.ruby-opt }}"
+      - name: Run tests
+        run: bundle exec rake
 
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Please keep this file alphabetized and organized
 #

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'rake'
 

--- a/gemfiles/nokogiri-1.5.gemfile
+++ b/gemfiles/nokogiri-1.5.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem "nokogiri", "~> 1.5.10"

--- a/lib/onelogin/ruby-saml.rb
+++ b/lib/onelogin/ruby-saml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'onelogin/ruby-saml/logging'
 require 'onelogin/ruby-saml/saml_message'
 require 'onelogin/ruby-saml/authrequest'

--- a/lib/onelogin/ruby-saml/attribute_service.rb
+++ b/lib/onelogin/ruby-saml/attribute_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OneLogin
   module RubySaml
 

--- a/lib/onelogin/ruby-saml/attributes.rb
+++ b/lib/onelogin/ruby-saml/attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OneLogin
   module RubySaml
 

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -64,7 +64,7 @@ module OneLogin
         request_doc = create_authentication_xml_doc(settings)
         request_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
 
-        request = ""
+        request = +""
         request_doc.write(request)
 
         Logging.debug "Created AuthnRequest: #{request}"

--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rexml/document"
 
 require "onelogin/ruby-saml/logging"
@@ -37,7 +39,7 @@ module OneLogin
         params = create_params(settings, params)
         params_prefix = (settings.idp_sso_service_url =~ /\?/) ? '&' : '?'
         saml_request = CGI.escape(params.delete("SAMLRequest"))
-        request_params = "#{params_prefix}SAMLRequest=#{saml_request}"
+        request_params = +"#{params_prefix}SAMLRequest=#{saml_request}"
         params.each_pair do |key, value|
           request_params << "&#{key}=#{CGI.escape(value.to_s)}"
         end

--- a/lib/onelogin/ruby-saml/error_handling.rb
+++ b/lib/onelogin/ruby-saml/error_handling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "onelogin/ruby-saml/validation_error"
 
 module OneLogin

--- a/lib/onelogin/ruby-saml/http_error.rb
+++ b/lib/onelogin/ruby-saml/http_error.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 module OneLogin
   module RubySaml
     class HttpError < StandardError
     end
   end
 end
-

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "base64"
 require "net/http"
 require "net/https"

--- a/lib/onelogin/ruby-saml/logging.rb
+++ b/lib/onelogin/ruby-saml/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 
 # Simplistic log class when we're running in Rails

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -61,7 +61,7 @@ module OneLogin
         request_doc = create_logout_request_xml_doc(settings)
         request_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
 
-        request = ""
+        request = +""
         request_doc.write(request)
 
         Logging.debug "Created SLO Logout Request: #{request}"

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "onelogin/ruby-saml/logging"
 require "onelogin/ruby-saml/saml_message"
 require "onelogin/ruby-saml/utils"
@@ -34,7 +36,7 @@ module OneLogin
         params = create_params(settings, params)
         params_prefix = (settings.idp_slo_service_url =~ /\?/) ? '&' : '?'
         saml_request = CGI.escape(params.delete("SAMLRequest"))
-        request_params = "#{params_prefix}SAMLRequest=#{saml_request}"
+        request_params = +"#{params_prefix}SAMLRequest=#{saml_request}"
         params.each_pair do |key, value|
           request_params << "&#{key}=#{CGI.escape(value.to_s)}"
         end

--- a/lib/onelogin/ruby-saml/logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/logoutresponse.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "xml_security"
 require "onelogin/ruby-saml/saml_message"
 

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "uri"
 
 require "onelogin/ruby-saml/logging"

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -161,16 +161,14 @@ module OneLogin
       end
 
       def output_xml(meta_doc, pretty_print)
-        ret = ''
-
         # pretty print the XML so IdP administrators can easily see what the SP supports
         if pretty_print
+          ret = +''
           meta_doc.write(ret, 1)
+          ret
         else
-          ret = meta_doc.to_s
+          meta_doc.to_s
         end
-
-        ret
       end
     end
   end

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "xml_security"
 require "onelogin/ruby-saml/attributes"
 

--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 require 'zlib'
 require 'base64'

--- a/lib/onelogin/ruby-saml/setting_error.rb
+++ b/lib/onelogin/ruby-saml/setting_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OneLogin
   module RubySaml
     class SettingError < StandardError

--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "xml_security"
 require "onelogin/ruby-saml/attribute_service"
 require "onelogin/ruby-saml/utils"

--- a/lib/onelogin/ruby-saml/slo_logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutrequest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'zlib'
 require 'time'
 require 'nokogiri'

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -70,7 +70,7 @@ module OneLogin
         response_doc = create_logout_response_xml_doc(settings, request_id, logout_message, logout_status_code)
         response_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
 
-        response = ""
+        response = +""
         response_doc.write(response)
 
         Logging.debug "Created SLO Logout Response: #{response}"

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "onelogin/ruby-saml/logging"
 
 require "onelogin/ruby-saml/saml_message"
@@ -39,7 +41,7 @@ module OneLogin
         params_prefix = (settings.idp_slo_service_url =~ /\?/) ? '&' : '?'
         url = settings.idp_slo_response_service_url || settings.idp_slo_service_url
         saml_response = CGI.escape(params.delete("SAMLResponse"))
-        response_params = "#{params_prefix}SAMLResponse=#{saml_response}"
+        response_params = +"#{params_prefix}SAMLResponse=#{saml_response}"
         params.each_pair do |key, value|
           response_params << "&#{key}=#{CGI.escape(value.to_s)}"
         end

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_VERSION < '1.9'
   require 'uuid'
 else
@@ -140,7 +142,7 @@ module OneLogin
       def self.build_query(params)
         type, data, relay_state, sig_alg = [:type, :data, :relay_state, :sig_alg].map { |k| params[k]}
 
-        url_string = "#{type}=#{CGI.escape(data)}"
+        url_string = +"#{type}=#{CGI.escape(data)}"
         url_string << "&RelayState=#{CGI.escape(relay_state)}" if relay_state
         url_string << "&SigAlg=#{CGI.escape(sig_alg)}"
       end
@@ -157,7 +159,7 @@ module OneLogin
       def self.build_query_from_raw_parts(params)
         type, raw_data, raw_relay_state, raw_sig_alg = [:type, :raw_data, :raw_relay_state, :raw_sig_alg].map { |k| params[k]}
 
-        url_string = "#{type}=#{raw_data}"
+        url_string = +"#{type}=#{raw_data}"
         url_string << "&RelayState=#{raw_relay_state}" if raw_relay_state
         url_string << "&SigAlg=#{raw_sig_alg}"
       end

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -32,7 +32,7 @@ module OneLogin
           (\d+)W                    # 8: Weeks
         )
       $)x.freeze
-      UUID_PREFIX = '_'
+      UUID_PREFIX = +'_'
 
       # Checks if the x509 cert provided is expired
       #
@@ -216,6 +216,8 @@ module OneLogin
       # @param status_message [Strig] StatusMessage value
       # @return [String] The status error message
       def self.status_error_msg(error_msg, raw_status_code = nil, status_message = nil)
+        error_msg = error_msg.dup
+
         unless raw_status_code.nil?
           if raw_status_code.include? "|"
             status_codes = raw_status_code.split(' | ')

--- a/lib/onelogin/ruby-saml/validation_error.rb
+++ b/lib/onelogin/ruby-saml/validation_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OneLogin
   module RubySaml
     class ValidationError < StandardError

--- a/lib/onelogin/ruby-saml/version.rb
+++ b/lib/onelogin/ruby-saml/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OneLogin
   module RubySaml
     VERSION = '1.16.0'

--- a/lib/ruby-saml.rb
+++ b/lib/ruby-saml.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'onelogin/ruby-saml'

--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # The contents of this file are subject to the terms
 # of the Common Development and Distribution License
 # (the License). You may not use this file except in

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'onelogin/ruby-saml/version'
 

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), 'test_helper'))
 
 require 'onelogin/ruby-saml/attributes'

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 require 'onelogin/ruby-saml/idp_metadata_parser'

--- a/test/logging_test.rb
+++ b/test/logging_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 require 'onelogin/ruby-saml/logging'

--- a/test/logout_responses/logoutresponse_fixtures.rb
+++ b/test/logout_responses/logoutresponse_fixtures.rb
@@ -1,4 +1,5 @@
 #encoding: utf-8
+# frozen_string_literal: true
 
 def default_logout_response_opts
   {

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 require 'onelogin/ruby-saml/logoutrequest'
@@ -213,7 +215,7 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
-        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string = +"SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -229,7 +231,7 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA256
 
-        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string = +"SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -245,7 +247,7 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA384
 
-        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string = +"SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -261,7 +263,7 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA512
 
-        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string = +"SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -314,7 +316,7 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
-        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string = +"SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 

--- a/test/logoutresponse_test.rb
+++ b/test/logoutresponse_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 require 'onelogin/ruby-saml/logoutresponse'

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 require 'onelogin/ruby-saml/metadata'

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 require 'onelogin/ruby-saml/authrequest'
@@ -292,7 +294,7 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
-        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string = +"SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -309,7 +311,7 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA256
 
-        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string = +"SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -393,7 +395,7 @@ class RequestTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
-        query_string = "SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
+        query_string = +"SAMLRequest=#{CGI.escape(params['SAMLRequest'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 require 'onelogin/ruby-saml/response'

--- a/test/saml_message_test.rb
+++ b/test/saml_message_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 class RubySamlTest < Minitest::Test

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 require 'onelogin/ruby-saml/settings'

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 require 'logout_responses/logoutresponse_fixtures'
 

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 require 'onelogin/ruby-saml/slo_logoutresponse'
@@ -196,7 +198,7 @@ class SloLogoutresponseTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
-        query_string = "SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
+        query_string = +"SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -215,7 +217,7 @@ class SloLogoutresponseTest < Minitest::Test
 
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA256
 
-        query_string = "SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
+        query_string = +"SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -234,7 +236,7 @@ class SloLogoutresponseTest < Minitest::Test
 
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA384
 
-        query_string = "SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
+        query_string = +"SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -253,7 +255,7 @@ class SloLogoutresponseTest < Minitest::Test
 
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA512
 
-        query_string = "SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
+        query_string = +"SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
@@ -315,7 +317,7 @@ class SloLogoutresponseTest < Minitest::Test
         assert params['Signature']
         assert_equal params['SigAlg'], XMLSecurity::Document::RSA_SHA1
 
-        query_string = "SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
+        query_string = +"SAMLResponse=#{CGI.escape(params['SAMLResponse'])}"
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 require 'simplecov-lcov'
 

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 class UtilsTest < Minitest::Test

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 require 'xml_security'
 


### PR DESCRIPTION
This option has been available for a very long time in Ruby, and will probably become the default in the semi-near future.

Ref: https://bugs.ruby-lang.org/issues/20205