### PR TITLE
Simplify dependency constraints in gemspec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest]
-        ruby-version: [2.1.9, 2.2.10, 2.3.8, 2.4.6, 2.5.8, 2.6.6, 2.7.2, 3.0.1, 3.1, 3.2, jruby-9.1.17.0, jruby-9.2.17.0, jruby-9.3.2.0, jruby-9.4.0.0, truffleruby]
+        ruby-version: [2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby-9.3, jruby-9.4, truffleruby]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         ruby-version: [2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby-9.3, jruby-9.4, truffleruby]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 2.6.0'
   s.summary = %q{SAML Ruby Tookit}
 
   s.add_runtime_dependency('nokogiri', '>= 1.13.10')

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -23,82 +23,15 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.7'
   s.summary = %q{SAML Ruby Tookit}
 
-  # Because runtime dependencies are determined at build time, we cannot make
-  # Nokogiri's version dependent on the Ruby version, even though we would
-  # have liked to constrain Ruby 1.8.7 to install only the 1.5.x versions.
-  if defined?(JRUBY_VERSION)
-    if JRUBY_VERSION < '9.1.7.0'
-      s.add_runtime_dependency('nokogiri', '>= 1.8.2', '<= 1.8.5')
-      s.add_runtime_dependency('jruby-openssl', '>= 0.9.8')
-      s.add_runtime_dependency('json', '< 2.3.0')
-    elsif JRUBY_VERSION < '9.2.0.0'
-      s.add_runtime_dependency('nokogiri', '>= 1.9.1', '< 1.10.0')
-    elsif JRUBY_VERSION < '9.3.2.0'
-      s.add_runtime_dependency('nokogiri', '>= 1.11.4')
-      s.add_runtime_dependency('rexml')
-    else
-      s.add_runtime_dependency('nokogiri', '>= 1.13.10')
-      s.add_runtime_dependency('rexml')
-    end
-  elsif RUBY_VERSION < '1.9'
-    s.add_runtime_dependency('uuid')
-    s.add_runtime_dependency('nokogiri', '<= 1.5.11')
-  elsif RUBY_VERSION < '2.1'
-    s.add_runtime_dependency('nokogiri', '>= 1.5.10', '<= 1.6.8.1')
-    s.add_runtime_dependency('json', '< 2.3.0')
-  elsif RUBY_VERSION < '2.3'
-    s.add_runtime_dependency('nokogiri', '>= 1.9.1', '< 1.10.0')
-  elsif RUBY_VERSION < '2.5'
-    s.add_runtime_dependency('nokogiri', '>= 1.10.10', '< 1.11.0')
-    s.add_runtime_dependency('rexml')
-  elsif RUBY_VERSION < '2.6'
-    s.add_runtime_dependency('nokogiri', '>= 1.11.4')
-    s.add_runtime_dependency('rexml')
-  else
-    s.add_runtime_dependency('nokogiri', '>= 1.13.10')
-    s.add_runtime_dependency('rexml')
-  end
+  s.add_runtime_dependency('nokogiri', '>= 1.13.10')
+  s.add_runtime_dependency('rexml')
 
   s.add_development_dependency('simplecov', '<0.22.0')
-  if RUBY_VERSION < '2.4.1'
-    s.add_development_dependency('simplecov-lcov', '<0.8.0')
-  else
-    s.add_development_dependency('simplecov-lcov', '>0.7.0')
-  end
-
+  s.add_development_dependency('simplecov-lcov', '>0.7.0')
   s.add_development_dependency('minitest', '~> 5.5', '<5.19.0')
   s.add_development_dependency('mocha',    '~> 0.14')
-
-  if RUBY_VERSION < '2.0'
-    s.add_development_dependency('rake',     '~> 10')
-  else
-    s.add_development_dependency('rake',     '>= 12.3.3')
-  end
-
+  s.add_development_dependency('rake',     '>= 12.3.3')
   s.add_development_dependency('shoulda',  '~> 2.11')
   s.add_development_dependency('systemu',  '~> 2')
-
-  if RUBY_VERSION < '2.1'
-    s.add_development_dependency('timecop',  '<= 0.6.0')
-  else
-    s.add_development_dependency('timecop',  '~> 0.9')
-  end
-
-  if defined?(JRUBY_VERSION)
-    # All recent versions of JRuby play well with pry
-    s.add_development_dependency('pry')
-  elsif RUBY_VERSION < '1.9'
-    # 1.8.7
-    s.add_development_dependency('ruby-debug', '~> 0.10.4')
-  elsif RUBY_VERSION < '2.0'
-    # 1.9.x
-    s.add_development_dependency('debugger-linecache', '~> 1.2.0')
-    s.add_development_dependency('debugger', '~> 1.6.4')
-  elsif RUBY_VERSION < '2.1'
-    # 2.0.x
-    s.add_development_dependency('byebug', '~> 2.1.1')
-  else
-    # 2.1.x, 2.2.x
-    s.add_development_dependency('pry-byebug')
-  end
+  s.add_development_dependency('timecop',  '~> 0.9')
 end


### PR DESCRIPTION
Looking at the latest release, 1.16.0 it depends on the it depends on everything in the `else` branches in the gemspec. https://rubygems.org/gems/ruby-saml/versions/1.16.0

Runtime

    nokogiri >= 1.13.10
    rexml >= 0

Development

    minitest ~> 5.5, < 5.19.0
    mocha ~> 0.14
    pry-byebug >= 0
    rake >= 12.3.3
    shoulda ~> 2.11
    simplecov < 0.22.0
    simplecov-lcov > 0.7.0
    systemu ~> 2
    timecop ~> 0.9

There has also never been a JRuby specific version published: https://rubygems.org/gems/ruby-saml/versions
so remove all special handling for JRuby.

If CI shows any need for it, we can add back constraints in the Gemfile.