### PR TITLE
[WIP - NOT READY] Support DSA and ECDSA signing keys

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -75,14 +75,14 @@ module OneLogin
         sp_signing_key = settings.get_sp_signing_key
 
         if settings.idp_sso_service_binding == Utils::BINDINGS[:redirect] && settings.security[:authn_requests_signed] && sp_signing_key
-          params['SigAlg'] = settings.security[:signature_method]
+          params['SigAlg'] = settings.get_sp_signature_method
           url_string = OneLogin::RubySaml::Utils.build_query(
             :type => 'SAMLRequest',
             :data => base64_request,
             :relay_state => relay_state,
             :sig_alg => params['SigAlg']
           )
-          sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
+          sign_algorithm = XMLSecurity::Crypto.hash_algorithm(settings.get_sp_signature_method)
           signature = sp_signing_key.sign(sign_algorithm.new, url_string)
           params['Signature'] = encode(signature)
         end
@@ -182,7 +182,7 @@ module OneLogin
       def sign_document(document, settings)
         cert, private_key = settings.get_sp_signing_pair
         if settings.idp_sso_service_binding == Utils::BINDINGS[:post] && settings.security[:authn_requests_signed] && private_key && cert
-          document.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
+          document.sign_document(private_key, cert, settings.get_sp_signature_method, settings.get_sp_digest_method)
         end
 
         document

--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -389,7 +389,7 @@ module OneLogin
 
             cert = OpenSSL::X509::Certificate.new(Base64.decode64(certificate))
 
-            fingerprint_alg = XMLSecurity::BaseDocument.new.algorithm(fingerprint_algorithm).new
+            fingerprint_alg = XMLSecurity::Crypto.hash_algorithm(fingerprint_algorithm).new
             fingerprint_alg.hexdigest(cert.to_der).upcase.scan(/../).join(":")
           end
         end

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -72,14 +72,14 @@ module OneLogin
         sp_signing_key = settings.get_sp_signing_key
 
         if settings.idp_slo_service_binding == Utils::BINDINGS[:redirect] && settings.security[:logout_requests_signed] && sp_signing_key
-          params['SigAlg'] = settings.security[:signature_method]
+          params['SigAlg'] = settings.get_sp_signature_method
           url_string = OneLogin::RubySaml::Utils.build_query(
             :type => 'SAMLRequest',
             :data => base64_request,
             :relay_state => relay_state,
             :sig_alg => params['SigAlg']
           )
-          sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
+          sign_algorithm = XMLSecurity::Crypto.hash_algorithm(settings.get_sp_signature_method)
           signature = settings.get_sp_signing_key.sign(sign_algorithm.new, url_string)
           params['Signature'] = encode(signature)
         end
@@ -141,7 +141,7 @@ module OneLogin
         # embed signature
         cert, private_key = settings.get_sp_signing_pair
         if settings.idp_slo_service_binding == Utils::BINDINGS[:post] && settings.security[:logout_requests_signed] && private_key && cert
-          document.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
+          document.sign_document(private_key, cert, settings.get_sp_signature_method, settings.get_sp_digest_method)
         end
 
         document

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -141,7 +141,7 @@ module OneLogin
         cert, private_key = settings.get_sp_signing_pair
         return unless private_key && cert
 
-        meta_doc.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
+        meta_doc.sign_document(private_key, cert, settings.get_sp_signature_method, settings.get_sp_digest_method)
       end
 
       def output_xml(meta_doc, pretty_print)

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -81,14 +81,14 @@ module OneLogin
         sp_signing_key = settings.get_sp_signing_key
 
         if settings.idp_slo_service_binding == Utils::BINDINGS[:redirect] && settings.security[:logout_responses_signed] && sp_signing_key
-          params['SigAlg'] = settings.security[:signature_method]
+          params['SigAlg'] = settings.get_sp_signature_method
           url_string = OneLogin::RubySaml::Utils.build_query(
             :type => 'SAMLResponse',
             :data => base64_response,
             :relay_state => relay_state,
             :sig_alg => params['SigAlg']
           )
-          sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
+          sign_algorithm = XMLSecurity::Crypto.hash_algorithm(settings.get_sp_signature_method)
           signature = sp_signing_key.sign(sign_algorithm.new, url_string)
           params['Signature'] = encode(signature)
         end
@@ -153,12 +153,11 @@ module OneLogin
         # embed signature
         cert, private_key = settings.get_sp_signing_pair
         if settings.idp_slo_service_binding == Utils::BINDINGS[:post] && private_key && cert
-          document.sign_document(private_key, cert, settings.security[:signature_method], settings.security[:digest_method])
+          document.sign_document(private_key, cert, settings.get_sp_signature_method, settings.get_sp_digest_method)
         end
 
         document
       end
-
     end
   end
 end

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -163,8 +163,8 @@ class IdpMetadataParserTest < Minitest::Test
         }
       })
       assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.idp_cert_fingerprint
-      assert_equal XMLSecurity::Document::SHA256, settings.security[:digest_method]
-      assert_equal XMLSecurity::Document::RSA_SHA256, settings.security[:signature_method]
+      assert_equal XMLSecurity::Document::SHA256, settings.get_sp_digest_method
+      assert_equal XMLSecurity::Document::RSA_SHA256, settings.get_sp_signature_method
     end
 
     it "merges results into given settings object" do
@@ -176,8 +176,8 @@ class IdpMetadataParserTest < Minitest::Test
       OneLogin::RubySaml::IdpMetadataParser.new.parse(idp_metadata_descriptor, :settings => settings)
 
       assert_equal "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72", settings.idp_cert_fingerprint
-      assert_equal XMLSecurity::Document::SHA256, settings.security[:digest_method]
-      assert_equal XMLSecurity::Document::RSA_SHA256, settings.security[:signature_method]
+      assert_equal XMLSecurity::Document::SHA256, settings.get_sp_digest_method
+      assert_equal XMLSecurity::Document::RSA_SHA256, settings.get_sp_signature_method
     end
   end
 

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -273,7 +273,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -289,7 +289,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA256
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -305,7 +305,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA384
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -321,7 +321,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA512
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -348,7 +348,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -409,7 +409,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end

--- a/test/logoutresponse_test.rb
+++ b/test/logoutresponse_test.rb
@@ -314,7 +314,7 @@ class RubySamlTest < Minitest::Test
           refute_equal(query, original_query)
           assert_equal(CGI.unescape(query), CGI.unescape(original_query))
           # Make normalised signature based on our modified params.
-          sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
+          sign_algorithm = XMLSecurity::Crypto.hash_algorithm(settings.get_sp_signature_method)
           signature = settings.get_sp_signing_key.sign(sign_algorithm.new, query)
           params['Signature'] = Base64.encode64(signature).gsub(/\n/, "")
           # Re-create the Logoutresponse based on these modified parameters,
@@ -350,7 +350,7 @@ class RubySamlTest < Minitest::Test
           refute_equal(query, original_query)
           assert_equal(CGI.unescape(query), CGI.unescape(original_query))
           # Make normalised signature based on our modified params.
-          sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
+          sign_algorithm = XMLSecurity::Crypto.hash_algorithm(settings.get_sp_signature_method)
           signature = settings.get_sp_signing_key.sign(sign_algorithm.new, query)
           params['Signature'] = Base64.encode64(signature).gsub(/\n/, "")
           # Re-create the Logoutresponse based on these modified parameters,

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -339,7 +339,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -355,7 +355,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA256
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -382,7 +382,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -474,7 +474,7 @@ class RequestTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
 
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -124,8 +124,8 @@ class SettingsTest < Minitest::Test
       new_settings = OneLogin::RubySaml::Settings.new
       assert_equal new_settings.security[:authn_requests_signed], false
       assert_equal new_settings.security[:embed_sign], false
-      assert_equal new_settings.security[:digest_method], XMLSecurity::Document::SHA1
-      assert_equal new_settings.security[:signature_method], XMLSecurity::Document::RSA_SHA1
+      assert_equal new_settings.get_sp_digest_method, XMLSecurity::Document::SHA1
+      assert_equal new_settings.get_sp_signature_method, XMLSecurity::Document::RSA_SHA1
     end
 
     it "overrides only provided security attributes passing a second parameter" do
@@ -397,7 +397,7 @@ class SettingsTest < Minitest::Test
 
       it "returns the private key when it is valid" do
         @settings.private_key = ruby_saml_key_text
-        assert @settings.get_sp_key.kind_of? OpenSSL::PKey::RSA
+        assert @settings.get_sp_key.kind_of?(OpenSSL::PKey::RSA)
       end
 
       it "raises when the private key is not valid" do

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -401,7 +401,7 @@ class RubySamlTest < Minitest::Test
         refute_equal(query, original_query)
         assert_equal(CGI.unescape(query), CGI.unescape(original_query))
         # Make normalised signature based on our modified params.
-        sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
+        sign_algorithm = XMLSecurity::Crypto.hash_algorithm(settings.get_sp_signature_method)
         signature = settings.get_sp_signing_key.sign(sign_algorithm.new, query)
         params['Signature'] = Base64.encode64(signature).gsub(/\n/, "")
         # Construct SloLogoutrequest and ask it to validate the signature.
@@ -436,7 +436,7 @@ class RubySamlTest < Minitest::Test
         refute_equal(query, original_query)
         assert_equal(CGI.unescape(query), CGI.unescape(original_query))
         # Make normalised signature based on our modified params.
-        sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(settings.security[:signature_method])
+        sign_algorithm = XMLSecurity::Crypto.hash_algorithm(settings.get_sp_signature_method)
         signature = settings.get_sp_signing_key.sign(sign_algorithm.new, query)
         params['Signature'] = Base64.encode64(signature).gsub(/\n/, "")
         # Construct SloLogoutrequest and ask it to validate the signature.
@@ -468,14 +468,12 @@ class RubySamlTest < Minitest::Test
         # send is based on this base64 request.
         params = {
           'SAMLRequest' => downcased_escape(base64_request),
-          'SigAlg' => downcased_escape(settings.security[:signature_method]),
+          'SigAlg' => downcased_escape(settings.get_sp_signature_method),
         }
         # Assemble query string.
         query = "SAMLRequest=#{params['SAMLRequest']}&SigAlg=#{params['SigAlg']}"
         # Make normalised signature based on our modified params.
-        sign_algorithm = XMLSecurity::BaseDocument.new.algorithm(
-          settings.security[:signature_method]
-        )
+        sign_algorithm = XMLSecurity::Crypto.hash_algorithm(settings.get_sp_signature_method)
         signature = settings.get_sp_signing_key.sign(sign_algorithm.new, query)
         params['Signature'] = downcased_escape(Base64.encode64(signature).gsub(/\n/, ""))
 

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -249,7 +249,7 @@ class SloLogoutresponseTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -268,7 +268,7 @@ class SloLogoutresponseTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA256
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -287,7 +287,7 @@ class SloLogoutresponseTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA384
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -306,7 +306,7 @@ class SloLogoutresponseTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA512
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -333,7 +333,7 @@ class SloLogoutresponseTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end
@@ -402,7 +402,7 @@ class SloLogoutresponseTest < Minitest::Test
         query_string << "&RelayState=#{CGI.escape(params[:RelayState])}"
         query_string << "&SigAlg=#{CGI.escape(params['SigAlg'])}"
 
-        signature_algorithm = XMLSecurity::BaseDocument.new.algorithm(params['SigAlg'])
+        signature_algorithm = XMLSecurity::Crypto.hash_algorithm(params['SigAlg'])
         assert_equal signature_algorithm, OpenSSL::Digest::SHA1
         assert cert.public_key.verify(signature_algorithm.new, Base64.decode64(params['Signature']), query_string)
       end

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -88,48 +88,48 @@ class XmlSecurityTest < Minitest::Test
   describe "#canon_algorithm" do
     it "C14N_EXCLUSIVE_1_0" do
       canon_algorithm = Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
-      assert_equal canon_algorithm, XMLSecurity::BaseDocument.new.canon_algorithm("http://www.w3.org/2001/10/xml-exc-c14n#")
-      assert_equal canon_algorithm, XMLSecurity::BaseDocument.new.canon_algorithm("http://www.w3.org/2001/10/xml-exc-c14n#WithComments")
-      assert_equal canon_algorithm, XMLSecurity::BaseDocument.new.canon_algorithm("other")
+      assert_equal canon_algorithm, XMLSecurity::Crypto.canon_algorithm("http://www.w3.org/2001/10/xml-exc-c14n#")
+      assert_equal canon_algorithm, XMLSecurity::Crypto.canon_algorithm("http://www.w3.org/2001/10/xml-exc-c14n#WithComments")
+      assert_equal canon_algorithm, XMLSecurity::Crypto.canon_algorithm("other")
     end
 
     it "C14N_1_0" do
       canon_algorithm = Nokogiri::XML::XML_C14N_1_0
-      assert_equal canon_algorithm, XMLSecurity::BaseDocument.new.canon_algorithm("http://www.w3.org/TR/2001/REC-xml-c14n-20010315")
-      assert_equal canon_algorithm, XMLSecurity::BaseDocument.new.canon_algorithm("http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments")
+      assert_equal canon_algorithm, XMLSecurity::Crypto.canon_algorithm("http://www.w3.org/TR/2001/REC-xml-c14n-20010315")
+      assert_equal canon_algorithm, XMLSecurity::Crypto.canon_algorithm("http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments")
     end
 
     it "XML_C14N_1_1" do
       canon_algorithm = Nokogiri::XML::XML_C14N_1_1
-      assert_equal canon_algorithm, XMLSecurity::BaseDocument.new.canon_algorithm("http://www.w3.org/2006/12/xml-c14n11")
-      assert_equal canon_algorithm, XMLSecurity::BaseDocument.new.canon_algorithm("http://www.w3.org/2006/12/xml-c14n11#WithComments")
+      assert_equal canon_algorithm, XMLSecurity::Crypto.canon_algorithm("http://www.w3.org/2006/12/xml-c14n11")
+      assert_equal canon_algorithm, XMLSecurity::Crypto.canon_algorithm("http://www.w3.org/2006/12/xml-c14n11#WithComments")
     end
   end
 
   describe "#algorithm" do
     it "SHA1" do
       alg = OpenSSL::Digest::SHA1
-      assert_equal alg, XMLSecurity::BaseDocument.new.algorithm("http://www.w3.org/2000/09/xmldsig#rsa-sha1")
-      assert_equal alg, XMLSecurity::BaseDocument.new.algorithm("http://www.w3.org/2000/09/xmldsig#sha1")
-      assert_equal alg, XMLSecurity::BaseDocument.new.algorithm("other")
+      assert_equal alg, XMLSecurity::Crypto.hash_algorithm("http://www.w3.org/2000/09/xmldsig#rsa-sha1")
+      assert_equal alg, XMLSecurity::Crypto.hash_algorithm("http://www.w3.org/2000/09/xmldsig#sha1")
+      assert_equal alg, XMLSecurity::Crypto.hash_algorithm("other")
     end
 
     it "SHA256" do
       alg = OpenSSL::Digest::SHA256
-      assert_equal alg, XMLSecurity::BaseDocument.new.algorithm("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256")
-      assert_equal alg, XMLSecurity::BaseDocument.new.algorithm("http://www.w3.org/2001/04/xmldsig-more#sha256")
+      assert_equal alg, XMLSecurity::Crypto.hash_algorithm("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256")
+      assert_equal alg, XMLSecurity::Crypto.hash_algorithm("http://www.w3.org/2001/04/xmldsig-more#sha256")
     end
 
     it "SHA384" do
       alg = OpenSSL::Digest::SHA384
-      assert_equal alg, XMLSecurity::BaseDocument.new.algorithm("http://www.w3.org/2001/04/xmldsig-more#rsa-sha384")
-      assert_equal alg, XMLSecurity::BaseDocument.new.algorithm("http://www.w3.org/2001/04/xmldsig-more#sha384")
+      assert_equal alg, XMLSecurity::Crypto.hash_algorithm("http://www.w3.org/2001/04/xmldsig-more#rsa-sha384")
+      assert_equal alg, XMLSecurity::Crypto.hash_algorithm("http://www.w3.org/2001/04/xmldsig-more#sha384")
     end
 
     it "SHA512" do
       alg = OpenSSL::Digest::SHA512
-      assert_equal alg, XMLSecurity::BaseDocument.new.algorithm("http://www.w3.org/2001/04/xmldsig-more#rsa-sha512")
-      assert_equal alg, XMLSecurity::BaseDocument.new.algorithm("http://www.w3.org/2001/04/xmldsig-more#sha512")
+      assert_equal alg, XMLSecurity::Crypto.hash_algorithm("http://www.w3.org/2001/04/xmldsig-more#rsa-sha512")
+      assert_equal alg, XMLSecurity::Crypto.hash_algorithm("http://www.w3.org/2001/04/xmldsig-more#sha512")
     end
   end
 
@@ -299,15 +299,19 @@ class XmlSecurityTest < Minitest::Test
     end
 
     describe "StarfieldTMS" do
-      let (:response) { OneLogin::RubySaml::Response.new(fixture(:starfield_response)) }
+      let(:response) { OneLogin::RubySaml::Response.new(fixture(:starfield_response)) }
 
       before do
         response.settings = OneLogin::RubySaml::Settings.new(:idp_cert_fingerprint => "8D:BA:53:8E:A3:B6:F9:F1:69:6C:BB:D9:D8:BD:41:B3:AC:4F:9D:4D")
       end
 
       it "be able to validate a good response" do
-        Timecop.freeze Time.parse('2012-11-28 17:55:00 UTC') do
+        Timecop.freeze(Time.parse('2012-11-28 17:55:00 UTC')) do
           response.stubs(:validate_subject_confirmation).returns(true)
+          response.is_valid?(true)
+          puts response.errors
+          puts response.document
+
           assert response.is_valid?
         end
       end

--- a/test/xml_security_test.rb
+++ b/test/xml_security_test.rb
@@ -308,10 +308,6 @@ class XmlSecurityTest < Minitest::Test
       it "be able to validate a good response" do
         Timecop.freeze(Time.parse('2012-11-28 17:55:00 UTC')) do
           response.stubs(:validate_subject_confirmation).returns(true)
-          response.is_valid?(true)
-          puts response.errors
-          puts response.document
-
           assert response.is_valid?
         end
       end


### PR DESCRIPTION
Fixes https://github.com/SAML-Toolkits/ruby-saml/issues/661

Currently RubySaml supports only RSA keys. The SAML standard can also support ECDSA and DSA keys. This PR adds support for both:
1. Validating IdP EC/DSA sigs **AND**
2. Using SP EC/DSA signing keys.

It includes the following changes, which are all done in a backward compatible manner:
- When generating SP metadata/requests, `settings.security[:signature_method]` now ignores the "rsa" component of its user-set value and automatically uses whatever type of SP signing public key you actually set (e.g. a DSA key) plus the "sha" component of the value.
   - (Previously, only RSA was supported, so this doesn't break anything.)
- `settings.security[:signature_method]` supports shortcut values `:sha1`, `:sha256`, etc.
   - Shortcuts `:rsa_sha256`, `:dsa_sha256` etc. also work, but as per above the "rsa"/"dsa" are ignored in favor of the SP public key type.
- Similar to above `settings.security[:digest_method]` supports shortcut values `sha1`, `sha256`, etc.
- New module `XMLSecurity::Crypto` is extracted from `XMLSecurity::Document`
- Cleaned-up code, including related to canonicalization

Things this PR does **NOT** do:
- I haven't yet looked at encryption. Probably, DSA/EC keys won't work with encryption (I'm unsure whether they actually _should_ work, given that DSA is supposedly for signing-only.) To use the functionality in this PR, you must either:
   - Disable SP encryption when using EC/DSA keys **OR**
   - Use separate SP signing vs. encryption keys (supported in #673), and make sure the encryption key is an RSA key.

**TODO:**
- [x] Ensure existing tests pass
- [ ] Test SP EC keys on metadata
- [ ] Test SP EC keys on messages
- [ ] Test SP DSA keys on metadata
- [ ] Test SP DSA keys on messages
- [ ] Test IdP EC keys on metadata
- [ ] Test IdP EC keys on messages
- [ ] Test IdP DSA keys on metadata
- [ ] Test IdP DSA keys on messages
- [ ] Investigate encryption