### PR TITLE
Master: Fix tests on Windows, add Ruby 3.3, and cleanup CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,57 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest]
-        ruby-version: [2.1.9, 2.2.10, 2.3.8, 2.4.6, 2.5.8, 2.6.6, 2.7.2, 3.0.1, 3.1, 3.2, jruby-9.1.17.0, jruby-9.2.17.0, jruby-9.3.2.0, jruby-9.4.0.0, truffleruby]
+        os:
+          - ubuntu-20.04
+          - macos-latest
+          - windows-latest
+        ruby-version:
+          - 2.1
+          - 2.2
+          - 2.3
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
+          - 3.3
+          - jruby-9.1
+          - jruby-9.2
+          - jruby-9.3
+          - jruby-9.4
+          - truffleruby
+        exclude:
+          - os: macos-latest
+            ruby-version: 2.1
+          - os: macos-latest
+            ruby-version: 2.2
+          - os: macos-latest
+            ruby-version: 2.3
+          - os: macos-latest
+            ruby-version: 2.4
+          - os: macos-latest
+            ruby-version: 2.5
+          - os: macos-latest
+            ruby-version: jruby-9.1
+          - os: macos-latest
+            ruby-version: jruby-9.2
+          - os: windows-latest
+            ruby-version: 2.1
+          - os: windows-latest
+            ruby-version: jruby-9.1
+          - os: windows-latest
+            ruby-version: jruby-9.2
+          - os: windows-latest
+            ruby-version: jruby-9.3
+          - os: windows-latest
+            ruby-version: jruby-9.4
+          - os: windows-latest
+            ruby-version: truffleruby
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Ruby SAML Changelog
 
 ### 1.17.0
+* [#687](https://github.com/SAML-Toolkits/ruby-saml/pull/687) Add CI coverage for Ruby 3.3 and Windows.
 * [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) Add `Settings#sp_cert_multi` paramter to facilitate SP certificate and key rotation.
 * [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) Support multiple simultaneous SP decryption keys via `Settings#sp_cert_multi` parameter.
 * [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) Deprecate `Settings#certificate_new` parameter.

--- a/README.md
+++ b/README.md
@@ -22,29 +22,9 @@ We created a demo project for Rails 4 that uses the latest version of this libra
 
 The following Ruby versions are covered by CI testing:
 
-* 2.1.x
-* 2.2.x
-* 2.3.x
-* 2.4.x
-* 2.5.x
-* 2.6.x
-* 2.7.x
-* 3.0.x
-* 3.1
-* 3.2
-* JRuby 9.1.x
-* JRuby 9.2.x
-* JRuby 9.3.X
-* JRuby 9.4.0
+* Ruby (MRI) 2.1 to 3.3
+* JRuby 9.1 to 9.4
 * TruffleRuby (latest)
-
-In addition, the following may work but are untested:
-
-* 1.8.7
-* 1.9.x
-* 2.0.x
-* JRuby 1.7.x
-* JRuby 9.0.x
 
 ## Adding Features, Pull Requests
 


### PR DESCRIPTION
On Windows, the DateTime class struggles with Float values for certain methods like `#next_year` some reason.