### PR TITLE
Make IdpMetadataParser#get_idp_metadata public

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -186,8 +186,6 @@ module OneLogin
         idpsso_descriptors.map {|id| IdpMetadata.new(id, id.parent.attributes["entityID"])}
       end
 
-      private
-
       # Retrieve the remote IdP metadata from the URL or a cached copy.
       # @param url [String] Url where the XML of the Identity Provider Metadata is published.
       # @param validate_cert [Boolean] If true and the URL is HTTPs, the cert of the domain is checked.
@@ -219,6 +217,8 @@ module OneLogin
           "Failed to fetch idp metadata: #{response.code}: #{response.message}"
         )
       end
+
+      private
 
       class IdpMetadata
         attr_reader :idpsso_descriptor, :entity_id


### PR DESCRIPTION
I have a use-case for being able to cache the intermediate fetch of
metadata in case of temporary failures, so rather than:

    parser.parse_remote(url)

I'd like to

    begin
      metadata = parser.get_idp_metadata(url, true)
      do_my_caching(metadata)
      parser.parse(metadata)
    rescue HttpError
      load_cache
    end

There's a fair amount of logic in the `get_idp_metadata` method that I'd
rather not need to re-implement. Right now I have this implemented with
`parser.send(:get_idp_metadata, url, true)` which is obviously not great
if the internals of this class change in the future. Can we move this
method to the public API?