### PR TITLE
v2.0: Settings params deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#686](https://github.com/SAML-Toolkits/ruby-saml/pull/686) Use SHA-256 as the default hashing algorithm everywhere instead of SHA-1, including signatures, fingerprints, and digests.
 * [#695](https://github.com/SAML-Toolkits/ruby-saml/pull/695) Deprecate `settings.compress_request` and `settings.compess_response` parameters.
 * [#690](https://github.com/SAML-Toolkits/ruby-saml/pull/690) Remove deprecated `settings.security[:embed_sign]` parameter.
+* [#697](https://github.com/SAML-Toolkits/ruby-saml/pull/697) Add deprecation for various parameters in `RubySaml::Settings`.
 
 ### 1.17.0
 * [#673](https://github.com/SAML-Toolkits/ruby-saml/pull/673) Add `Settings#sp_cert_multi` paramter to facilitate SP certificate and key rotation.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -80,6 +80,18 @@ The SAML SP request/response message compression behavior is now controlled auto
 "compression" is used to make redirect URLs which contain SAML messages be shorter. For POST messages,
 compression may be achieved by enabling `Content-Encoding: gzip` on your webserver.
 
+## Settings deprecations
+
+The following parameters in `RubySaml::Settings` are deprecated and will be removed in RubySaml 2.1.0:
+
+- `#issuer` is deprecated and replaced 1:1 by `#sp_entity_id`
+- `#idp_sso_target_url` is deprecated and replaced 1:1 by `#idp_sso_service_url`
+- `#idp_slo_target_url` is deprecated and replaced 1:1 by `#idp_slo_service_url`
+- `#assertion_consumer_logout_service_url` is deprecated and replaced 1:1 by `#single_logout_service_url`
+- `#assertion_consumer_logout_service_binding` is deprecated and replaced 1:1 by `#single_logout_service_binding`
+- `#certificate_new` is deprecated and replaced by `#sp_cert_multi`. Refer to documentation as `#sp_cert_multi`
+  has a different value type than `#certificate_new`.
+
 ## Updating from 1.12.x to 1.13.0
 
 Version `1.13.0` adds `settings.idp_sso_service_binding` and `settings.idp_slo_service_binding`, and

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -35,8 +35,10 @@ class SettingsTest < Minitest::Test
 
     it "should provide getters and settings for binding parameters" do
       accessors = [
-        :protocol_binding, :assertion_consumer_service_binding,
-        :single_logout_service_binding, :assertion_consumer_logout_service_binding
+        :protocol_binding,
+        :assertion_consumer_service_binding,
+        :single_logout_service_binding,
+        :assertion_consumer_logout_service_binding
       ]
 
       accessors.each do |accessor|


### PR DESCRIPTION
Deprecate `RubySaml#Settings` params and alias them to the new ones. All these deprecations were declared in CHANGELOG in earlier versions already. *This does not affect any existing behavior.*

- issuer --> sp_entity_id
- idp_sso_target_url --> idp_sso_service_url
- idp_slo_target_url --> idp_slo_service_url
- assertion_consumer_logout_service_url --> single_logout_service_url
- assertion_consumer_logout_service_binding --> single_logout_service_binding
