### PR TITLE
[READY] 2.x - Deprecate idp_cert_fingerprint / idp_cert_fingerprint_algorithm + README cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#692](https://github.com/SAML-Toolkits/ruby-saml/pull/692) Remove `XMLSecurity` namespace and replace with `RubySaml::XML`.
 * [#686](https://github.com/SAML-Toolkits/ruby-saml/pull/686) Use SHA-256 as the default hashing algorithm everywhere instead of SHA-1, including signatures, fingerprints, and digests.
 * [#695](https://github.com/SAML-Toolkits/ruby-saml/pull/695) Deprecate `settings.compress_request` and `settings.compess_response` parameters.
+* [#701](https://github.com/SAML-Toolkits/ruby-saml/pull/695) Deprecate `settings.idp_cert_fingerprint` and `settings.idp_cert_fingerprint_algorithm` parameters.
 * [#690](https://github.com/SAML-Toolkits/ruby-saml/pull/690) Remove deprecated `settings.security[:embed_sign]` parameter.
 * [#697](https://github.com/SAML-Toolkits/ruby-saml/pull/697) Add deprecation for various parameters in `RubySaml::Settings`.
 * [#709](https://github.com/SAML-Toolkits/ruby-saml/pull/709) Allow passing in `Net::HTTP` `:open_timeout`, `:read_timeout`, and `:max_retries` settings to `IdpMetadataParser#parse_remote`.

--- a/README.md
+++ b/README.md
@@ -239,20 +239,21 @@ end
 
 ## Signature Validation
 
-Ruby SAML allows different ways to validate the signature of the SAMLResponse:
-- You can provide the IdP X.509 public certificate at the `idp_cert` setting.
-- You can provide the IdP X.509 public certificate in fingerprint format using the
- `idp_cert_fingerprint` setting parameter and additionally the `idp_cert_fingerprint_algorithm` parameter.
+Ruby SAML allows different ways to validate the signature of the SAML Response:
+- You may provide the IdP X.509 public certificate at the `idp_cert` setting.
+- (Deprecated) You may provide the IdP X.509 public certificate in fingerprint format using the
+  `idp_cert_fingerprint` and `idp_cert_fingerprint_algorithm` parameters.
 
-When validating the signature of redirect binding, the fingerprint is useless and the certificate
-of the IdP is required in order to execute the validation. You can pass the option
-`:relax_signature_validation` to `SloLogoutrequest` and `Logoutresponse` if want to avoid signature
-validation if no certificate of the IdP is provided.
+In addition, you may pass the option `:relax_signature_validation` to `SloLogoutrequest` and
+`Logoutresponse` if want to skip signature validation on logout.
 
-In production also we highly recommend to register on the settings the IdP certificate instead
-of using the fingerprint method. The fingerprint, is a hash, so at the end is open to a collision
-attack that can end on a signature validation bypass. Other SAML toolkits deprecated that mechanism,
-we maintain it for compatibility and also to be used on test environment.
+The `idp_cert_fingerprint` option is deprecated for the following reasons. It will be
+removed in Ruby SAML version 3.0.
+1. It only works with HTTP-POST binding, not HTTP-Redirect, since the full certificate
+   is not sent in the Redirect URL parameters.
+2. It is theoretically be susceptible to collision attacks, by which a malicious
+   actor could impersonate the IdP. (However, as of January 2025, such attacks have not
+   been publicly demonstrated for SHA-256.)
 
 ## Handling Multiple IdP Certificates
 

--- a/README.md
+++ b/README.md
@@ -248,12 +248,13 @@ In addition, you may pass the option `:relax_signature_validation` to `SloLogout
 `Logoutresponse` if want to skip signature validation on logout.
 
 The `idp_cert_fingerprint` option is deprecated for the following reasons. It will be
-removed in Ruby SAML version 3.0.
+removed in Ruby SAML version 2.1.0.
 1. It only works with HTTP-POST binding, not HTTP-Redirect, since the full certificate
    is not sent in the Redirect URL parameters.
 2. It is theoretically be susceptible to collision attacks, by which a malicious
    actor could impersonate the IdP. (However, as of January 2025, such attacks have not
    been publicly demonstrated for SHA-256.)
+3. It has been removed already from several other SAML libraries in other languages.
 
 ## Handling Multiple IdP Certificates
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -113,6 +113,13 @@ The SAML SP request/response message compression behavior is now controlled auto
 "compression" is used to make redirect URLs which contain SAML messages be shorter. For POST messages,
 compression may be achieved by enabling `Content-Encoding: gzip` on your webserver.
 
+### Deprecation of IdP certificate fingerprint settings
+
+The `settings.idp_cert_fingerprint` and `settings.idp_cert_fingerprint_algorithm` are deprecated
+and will be removed in RubySaml 2.1.0. Please use `settings.idp_cert` or `settings.idp_cert_multi` instead.
+The reasons for this deprecation are that (1) fingerprint cannot be used with HTTP-Redirect binding,
+and (2) fingerprint is theoretically susceptible to collision attacks.
+
 ### Other settings deprecations
 
 The following parameters in `RubySaml::Settings` are deprecated and will be removed in RubySaml 2.1.0:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -97,7 +97,7 @@ request.uuid #=> "my_id_a1b3c5d7-9f1e-3d5c-7b1a-9f1e3d5c7b1a"
 ```
 
 A side-effect of this change is that the `uuid` of the `Authrequest`, `Logoutrequest`, and `Logoutresponse`
-classes now is `nil` until the `#create` method is called (previously, it was set in the constructor.)
+classes now is `nil` until the `#create` method is called (previously, it was set in the initializer.)
 After calling `#create` for the first time the `uuid` will not change, even if a `Settings` object with
 a different `sp_uuid_prefix` is passed-in on subsequent calls.
 
@@ -215,7 +215,7 @@ the [CVE-2017-11428](https://www.cvedetails.com/cve/CVE-2017-11428/) vulnerabili
 
 Version `1.6.0` changes the preferred way to construct instances of `Logoutresponse` and
 `SloLogoutrequest`. Previously the _SAMLResponse_, _RelayState_, and _SigAlg_ parameters
-of these message types were provided via the constructor's `options[:get_params]` parameter.
+of these message types were provided via the initializer's `options[:get_params]` parameter.
 Unfortunately this can result in incompatibility with other SAML implementations; signatures
 are specified to be computed based on the _sender's_ URI-encoding of the message, which can
 differ from that of Ruby SAML. In particular, Ruby SAML's URI-encoding does not match that

--- a/lib/ruby_saml/settings.rb
+++ b/lib/ruby_saml/settings.rb
@@ -36,8 +36,8 @@ module RubySaml
     attr_accessor :idp_slo_service_url
     attr_accessor :idp_slo_response_service_url
     attr_accessor :idp_cert
-    attr_accessor :idp_cert_fingerprint
-    attr_accessor :idp_cert_fingerprint_algorithm
+    attr_reader   :idp_cert_fingerprint
+    attr_reader   :idp_cert_fingerprint_algorithm
     attr_accessor :idp_cert_multi
     attr_accessor :idp_attribute_names
     attr_accessor :idp_name_qualifier
@@ -306,6 +306,18 @@ module RubySaml
     end
 
     # @deprecated Will be removed in v2.1.0
+    def idp_cert_fingerprint=(value)
+      idp_cert_fingerprint_deprecation
+      @idp_cert_fingerprint = value
+    end
+
+    # @deprecated Will be removed in v2.1.0
+    def idp_cert_fingerprint_algorithm=(value)
+      idp_cert_fingerprint_deprecation
+      @idp_cert_fingerprint_algorithm = value
+    end
+
+    # @deprecated Will be removed in v2.1.0
     def certificate_new
       certificate_new_deprecation
       @certificate_new
@@ -347,6 +359,13 @@ module RubySaml
     def replaced_deprecation(old_param, new_param)
       Logging.deprecate "`RubySaml::Settings##{old_param}` is deprecated and will be removed in RubySaml 2.1.0. " \
                         "Please set the same value to `RubySaml::Settings##{new_param}` instead."
+    end
+
+    # @deprecated Will be removed in v2.1.0
+    def idp_cert_fingerprint_deprecation
+      Logging.deprecate '`RubySaml::Settings#idp_cert_fingerprint` and `#idp_cert_fingerprint_algorithm` are ' \
+                        'deprecated and will be removed in RubySaml v2.1.0. Please provide the full IdP certificate in ' \
+                        '`RubySaml::Settings#idp_cert` instead.'
     end
 
     # @deprecated Will be removed in v2.1.0


### PR DESCRIPTION
- Deprecate idp_cert_fingerprint and idp_cert_fingerprint_algorithm options (to remove in 2,1.0)
- Improvements to README:
  - Edits for clarity & brevity
  - Replace terminology "authorization" with "authentication"
  - Remove OneLogin references
  - Spelling fixes, etc.
  - Replace hash rockets with colons