### PR TITLE
Allow passing in timeout/retry settings to Net::HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#695](https://github.com/SAML-Toolkits/ruby-saml/pull/695) Deprecate `settings.compress_request` and `settings.compess_response` parameters.
 * [#690](https://github.com/SAML-Toolkits/ruby-saml/pull/690) Remove deprecated `settings.security[:embed_sign]` parameter.
 * [#697](https://github.com/SAML-Toolkits/ruby-saml/pull/697) Add deprecation for various parameters in `RubySaml::Settings`.
+* [#709](https://github.com/SAML-Toolkits/ruby-saml/pull/709) Allow passing in `Net::HTTP` `:open_timeout`, `:read_timeout`, and `:max_retries` settings to `IdpMetadataParser#parse_remote`.
 
 ### 1.17.0
 * [#687](https://github.com/SAML-Toolkits/ruby-saml/pull/687) Add CI coverage for Ruby 3.3 and Windows.


### PR DESCRIPTION
Replaces https://github.com/SAML-Toolkits/ruby-saml/pull/677

Allow passing in `Net::HTTP` `:open_timeout`, `:read_timeout`, and `:max_retries` settings to `IdpMetadataParser#parse_remote`.

> When fetching remote XML files from arbitrary URLs, you might want to configure different values for timeouts/retries to avoid allowing users to DoS you via intentionally slow endpoints. The Net::HTTP defaults are 60 seconds plus 1 retry, which could easily deplete resources if intentionally exploited.

I also added some additional test coverage for `IdpMetadataParser#parse_remote_to_array` which was missing.