### PR TITLE
Raise meaningful error when IDP descriptor cant be found

### DIFF
--- a/lib/onelogin/ruby-saml/idp_metadata_parser.rb
+++ b/lib/onelogin/ruby-saml/idp_metadata_parser.rb
@@ -3,6 +3,7 @@ require "net/http"
 require "net/https"
 require "rexml/document"
 require "rexml/xpath"
+require "onelogin/ruby-saml/setting_error"
 
 # Only supports SAML 2.0
 module OneLogin
@@ -180,7 +181,7 @@ module OneLogin
 
         idpsso_descriptors = self.class.get_idps(@document, options[:entity_id])
         if !idpsso_descriptors.any?
-          raise ArgumentError.new("idp_metadata must contain an IDPSSODescriptor element")
+          raise SettingError.new("idp_metadata must contain an IDPSSODescriptor element")
         end
 
         idpsso_descriptors.map {|id| IdpMetadata.new(id, id.parent.attributes["entityID"])}

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -495,7 +495,7 @@ class IdpMetadataParserTest < Minitest::Test
     end
 
     it "raise due no IDPSSODescriptor element" do
-        assert_raises(ArgumentError) { @idp_metadata_parser.parse(@idp_metadata) }
+        assert_raises(OneLogin::RubySaml::SettingError) { @idp_metadata_parser.parse(@idp_metadata) }
     end
   end
 


### PR DESCRIPTION
Here, raise a more meaningful error when the identity provider metadata does not contain an IDP descriptor, or no IDP descriptor matching the value of the optional `entity_id` option.

Using namespaced, specific errors makes the API easier and safer for user code.