### PR TITLE
Update for frozen string compatibility

### DIFF
--- a/lib/onelogin/ruby-saml/authrequest.rb
+++ b/lib/onelogin/ruby-saml/authrequest.rb
@@ -64,7 +64,7 @@ module OneLogin
         request_doc = create_authentication_xml_doc(settings)
         request_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
 
-        request = ""
+        request = String.new("")
         request_doc.write(request)
 
         Logging.debug "Created AuthnRequest: #{request}"

--- a/lib/onelogin/ruby-saml/logoutrequest.rb
+++ b/lib/onelogin/ruby-saml/logoutrequest.rb
@@ -61,7 +61,7 @@ module OneLogin
         request_doc = create_logout_request_xml_doc(settings)
         request_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
 
-        request = ""
+        request = String.new
         request_doc.write(request)
 
         Logging.debug "Created SLO Logout Request: #{request}"

--- a/lib/onelogin/ruby-saml/logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/logoutresponse.rb
@@ -140,7 +140,7 @@ module OneLogin
       def validate_success_status
         return true if success?
 
-        error_msg = 'The status code of the Logout Response was not Success'
+        error_msg = String.new('The status code of the Logout Response was not Success')
         status_error_msg = OneLogin::RubySaml::Utils.status_error_msg(error_msg, status_code, status_message)
         append_error(status_error_msg)
       end

--- a/lib/onelogin/ruby-saml/metadata.rb
+++ b/lib/onelogin/ruby-saml/metadata.rb
@@ -145,7 +145,7 @@ module OneLogin
       end
 
       def output_xml(meta_doc, pretty_print)
-        ret = ''
+        ret = String.new("")
 
         # pretty print the XML so IdP administrators can easily see what the SP supports
         if pretty_print

--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -412,7 +412,7 @@ module OneLogin
       def validate_success_status
         return true if success?
 
-        error_msg = 'The status code of the Response was not Success'
+        error_msg = String.new('The status code of the Response was not Success')
         status_error_msg = OneLogin::RubySaml::Utils.status_error_msg(error_msg, status_code, status_message)
         append_error(status_error_msg)
       end

--- a/lib/onelogin/ruby-saml/slo_logoutresponse.rb
+++ b/lib/onelogin/ruby-saml/slo_logoutresponse.rb
@@ -70,7 +70,7 @@ module OneLogin
         response_doc = create_logout_response_xml_doc(settings, request_id, logout_message, logout_status_code)
         response_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
 
-        response = ""
+        response = String.new("")
         response_doc.write(response)
 
         Logging.debug "Created SLO Logout Response: #{response}"

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -32,7 +32,7 @@ module OneLogin
           (\d+)W                    # 8: Weeks
         )
       $)x.freeze
-      UUID_PREFIX = '_'
+      UUID_PREFIX = String.new('_')
 
       # Checks if the x509 cert provided is expired.
       #

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -225,7 +225,7 @@ class UtilsTest < Minitest::Test
 
   describe ".status_error_msg" do
     it "returns a error msg with status_code and status message" do
-      error_msg = "The status code of the Logout Response was not Success"
+      error_msg = String.new("The status code of the Logout Response was not Success")
       status_code = "urn:oasis:names:tc:SAML:2.0:status:Requester"
       status_message = "The request could not be performed due to an error on the part of the requester."
       status_error_msg = OneLogin::RubySaml::Utils.status_error_msg(error_msg, status_code, status_message)
@@ -233,7 +233,7 @@ class UtilsTest < Minitest::Test
     end
 
     it "returns a error msg with status_code" do
-      error_msg = "The status code of the Logout Response was not Success"
+      error_msg = String.new("The status code of the Logout Response was not Success")
       status_code = "urn:oasis:names:tc:SAML:2.0:status:Requester"
       status_error_msg = OneLogin::RubySaml::Utils.status_error_msg(error_msg, status_code)
       assert_equal "The status code of the Logout Response was not Success, was Requester", status_error_msg


### PR DESCRIPTION
This marks mutable strings to allow tests to pass with

    RUBYOPT="--enable-frozen-string-literal"

enabled.

This will be the default in future Ruby versions, so being compatible now is ideal.