### PR TITLE
fix ambiguous regex warnings

### DIFF
--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -360,11 +360,11 @@ class UtilsTest < Minitest::Test
     end
 
     it 'successfully decrypts with the first private key' do
-      assert_match /\A<saml:Assertion/, OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [private_key])
+      assert_match %r{\A<saml:Assertion}, OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [private_key])
     end
 
     it 'successfully decrypts with a subsequent private key' do
-      assert_match /\A<saml:Assertion/, OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [invalid_key1, private_key])
+      assert_match %r{\A<saml:Assertion}, OneLogin::RubySaml::Utils.decrypt_multi(encrypted, [invalid_key1, private_key])
     end
 
     it 'raises an error when there is only one key and it fails to decrypt' do


### PR DESCRIPTION
This test warns

    warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator

We can fix this warning by using the %r regex syntax instead