### PR TITLE
Allow SP certificates to be OpenSSL::X509::Certificate

### DIFF
--- a/lib/ruby_saml/settings.rb
+++ b/lib/ruby_saml/settings.rb
@@ -375,13 +375,13 @@ module RubySaml
     def validate_sp_certs_params!
       has_multi = sp_cert_multi && !sp_cert_multi.empty?
       has_pk = private_key && !private_key.empty?
-      if has_multi && (has_cert?(certificate) || has_cert?(certificate_new) || has_pk)
+      if has_multi && (cert?(certificate) || cert?(certificate_new) || has_pk)
         raise ArgumentError.new("Cannot specify both sp_cert_multi and certificate, certificate_new, private_key parameters")
       end
     end
 
     # Check if a certificate is present.
-    def has_cert?(cert)
+    def cert?(cert)
       return true if cert.is_a?(OpenSSL::X509::Certificate)
 
       cert && !cert.empty?

--- a/lib/ruby_saml/utils.rb
+++ b/lib/ruby_saml/utils.rb
@@ -119,6 +119,7 @@ module RubySaml
     # @param pem [String] The original certificate
     # @return [OpenSSL::X509::Certificate] The certificate object
     def build_cert_object(pem)
+      return pem if pem.is_a?(OpenSSL::X509::Certificate)
       return unless (pem = PemFormatter.format_cert(pem, multi: false))
 
       OpenSSL::X509::Certificate.new(pem)
@@ -129,6 +130,7 @@ module RubySaml
     # @param pem [String] The original private key.
     # @return [OpenSSL::PKey::PKey] The private key object.
     def build_private_key_object(pem)
+      return pem if pem.is_a?(OpenSSL::PKey::PKey)
       return unless (pem = PemFormatter.format_private_key(pem, multi: false))
 
       error = nil

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -156,6 +156,11 @@ class UtilsTest < Minitest::Test
       end
     end
 
+    it 'returns the original certificate when an OpenSSL::X509::Certificate is given' do
+      certificate = OpenSSL::X509::Certificate.new
+      assert_same certificate, RubySaml::Utils.build_cert_object(certificate)
+    end
+
     it 'returns nil for nil certificate string' do
       assert_nil RubySaml::Utils.build_cert_object(nil)
     end
@@ -177,6 +182,13 @@ class UtilsTest < Minitest::Test
         pem = CertificateHelper.generate_private_key(algorithm).to_pem
         private_key_object = RubySaml::Utils.build_private_key_object(pem)
         assert_instance_of(expected_key_class(algorithm), private_key_object)
+      end
+    end
+
+    [OpenSSL::PKey::RSA, OpenSSL::PKey::DSA, OpenSSL::PKey::EC].each do |key_class|
+      it 'returns the original private key when an instance of OpenSSL::PKey::PKey is given' do
+        private_key = key_class.new
+        assert_same private_key, RubySaml::Utils.build_private_key_object(private_key)
       end
     end
 


### PR DESCRIPTION
This allows settings to accept instances of OpenSSL::X509::Certificate as service provider (SP) certificates.

Solves #723 

Version 1.16.0 was, at least partially, able to handle `OpenSSL::X509::Certificate` as input for settings.certificate (e.g. when using   `OneLogin::RubySaml::Response`).

Since `settings.get_sp_certs` is the only interface that is used to access certificates, it should be enough to test that interface with instances of `OpenSSL::X509::Certificate`. There are 3 ways to insert certs, all of them have been tested:
- settings.certificate
- settings.certificate_new
- settings.sp_cert_multi

Note that both deprecated interfaces `settings.get_sp_cert` and `settings.get_sp_cert_new` use `settings.get_sp_certs` internally. Thus, they are covered as well.

Same approach could be used for SP private key to accept `OpenSSL::PKey`.
Maybe it's a good idea to make all certificates from settings `attr_writer` for public and `attr_accessor` for private access to ensure that certs are accessed via `settings.get_sp_certs` only (but that would break current interface).