### PR TITLE
Introduce thread safety to SAML schema read

### DIFF
--- a/lib/onelogin/ruby-saml/saml_message.rb
+++ b/lib/onelogin/ruby-saml/saml_message.rb
@@ -19,15 +19,13 @@ module OneLogin
       PROTOCOL  = "urn:oasis:names:tc:SAML:2.0:protocol".freeze
 
       BASE64_FORMAT = %r(\A([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?\Z)
-      @@mutex = Mutex.new
 
       # @return [Nokogiri::XML::Schema] Gets the schema object of the SAML 2.0 Protocol schema
       #
       def self.schema
-        @@mutex.synchronize do
-          Dir.chdir(File.expand_path("../../../schemas", __FILE__)) do
-            ::Nokogiri::XML::Schema(File.read("saml-schema-protocol-2.0.xsd"))
-          end
+        path = File.expand_path("../../../schemas/saml-schema-protocol-2.0.xsd", __FILE__)
+        File.open(path) do |file|
+          ::Nokogiri::XML::Schema(file)
         end
       end
 


### PR DESCRIPTION
## Problem
As the related PR below, use of Dir.chdir is not thread-safe. This usage was causing exceptions to be raised when running on Puma and in other multi-threaded environments.

Related:
- https://github.com/SAML-Toolkits/ruby-saml/pull/175

## How to fix
This patch replaces `Dir.chdir` with thread-safe `File.open` method.

## Additional information
This patch also removes `@@mutex`, which became unnecessary.