### PR TITLE
Implement handling of CBC padding for symmetric decryption.

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -1029,7 +1029,7 @@ module OneLogin
       # @return [REXML::Document] The decrypted EncryptedAssertion element
       #
       def decrypt_assertion(encrypted_assertion_node)
-        decrypt_element(encrypted_assertion_node, /(.*<\/(\w+:)?Assertion>)/m)
+        decrypt_element(encrypted_assertion_node)
       end
 
       # Decrypts an EncryptedID element
@@ -1037,7 +1037,7 @@ module OneLogin
       # @return [REXML::Document] The decrypted EncrypedtID element
       #
       def decrypt_nameid(encrypted_id_node)
-        decrypt_element(encrypted_id_node, /(.*<\/(\w+:)?NameID>)/m)
+        decrypt_element(encrypted_id_node)
       end
 
       # Decrypts an EncryptedAttribute element
@@ -1045,7 +1045,7 @@ module OneLogin
       # @return [REXML::Document] The decrypted EncryptedAttribute element
       #
       def decrypt_attribute(encrypted_attribute_node)
-        decrypt_element(encrypted_attribute_node, /(.*<\/(\w+:)?Attribute>)/m)
+        decrypt_element(encrypted_attribute_node)
       end
 
       # Decrypt an element
@@ -1053,7 +1053,7 @@ module OneLogin
       # @param regexp [Regexp] The regular expression to extract the decrypted data
       # @return [REXML::Document] The decrypted element
       #
-      def decrypt_element(encrypt_node, regexp)
+      def decrypt_element(encrypt_node)
         if settings.nil? || settings.get_sp_decryption_keys.empty?
           raise ValidationError.new('An ' + encrypt_node.name + ' found and no SP private key found on the settings to decrypt it')
         end
@@ -1065,10 +1065,6 @@ module OneLogin
         end
 
         elem_plaintext = OneLogin::RubySaml::Utils.decrypt_multi(encrypt_node, settings.get_sp_decryption_keys)
-
-        # If we get some problematic noise in the plaintext after decrypting.
-        # This quick regexp parse will grab only the Element and discard the noise.
-        elem_plaintext = elem_plaintext.match(regexp)[0]
 
         # To avoid namespace errors if saml namespace is not defined
         # create a parent node first with the namespace defined

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -386,7 +386,7 @@ module OneLogin
           # If the padding is not within the bounds of the block size, the padding cannot be removed. If the padding is
           # larger than the block size, then the padding was created incorrectly.
           # This ISO 10126 padding is described at https://www.w3.org/TR/xmlenc-core1/#sec-Padding.
-          if padding_size <= cipher.block_size && padding_size <= assertion_plaintext.bytesize
+          if !padding_size.nil? && padding_size <= cipher.block_size && padding_size <= assertion_plaintext.bytesize
             assertion_plaintext = assertion_plaintext.byteslice(0, assertion_plaintext.bytesize - padding_size)
           else
             raise StandardError.new("Invalid ciphertext padding.")


### PR DESCRIPTION
AES and 3DES, when used with encrypted assertions with CBC padding, use a form of padding called ISO 10126 and is documented here: https://www.w3.org/TR/xmlenc-core1/#sec-Padding.


The current implementation calls this "noise" and uses a regular expression to attempt to extract the plaintext without the padding. Rather than use a regular expression, this implements correct handling of the padding.]]

This is more of a correctness thing than addressing any particular issue. Since the padding is random it could, in theory, be something like `NameID>` which would incorrectly be handled by the regex.

The unit tests already handle the padding aspect. Removing the regular expressions without the padding handling caused test failures. Rather than introduce any new tests, existing tests are used to validate the changes.