### PR TITLE
Skip sporadic Zlib::BufError failures in JRuby tests

### DIFF
--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -59,6 +59,12 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency('rexml')
   end
 
+  if RUBY_VERSION >= '3.4.0'
+    s.add_runtime_dependency("logger")
+    s.add_runtime_dependency("base64")
+    s.add_runtime_dependency('mutex_m')
+  end
+
   s.add_development_dependency('simplecov', '<0.22.0')
   if RUBY_VERSION < '2.4.1'
     s.add_development_dependency('simplecov-lcov', '<0.8.0')

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -1160,7 +1160,7 @@ class RubySamlTest < Minitest::Test
 
       it "optionally allows for clock drift on NotOnOrAfter" do
         # Java Floats behave differently than MRI
-        java = defined?(RUBY_ENGINE) && %w[jruby truffleruby].include?(RUBY_ENGINE)
+        java = jruby? || truffleruby?
 
         settings.soft = true
 

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -211,7 +211,7 @@ class RubySamlTest < Minitest::Test
 
       it "optionally allows for clock drift" do
         # Java Floats behave differently than MRI
-        java = defined?(RUBY_ENGINE) && %w[jruby truffleruby].include?(RUBY_ENGINE)
+        java = jruby? || truffleruby?
 
         logout_request.soft = true
         logout_request.document.root.attributes['NotOnOrAfter'] = '2011-06-14T18:31:01.516Z'


### PR DESCRIPTION
Same as https://github.com/SAML-Toolkits/ruby-saml/pull/734 from v2 branch

Refer to https://github.com/jruby/jruby/issues/6613

Fixes https://github.com/SAML-Toolkits/ruby-saml/issues/708  