### PR TITLE
[READY] V2.x - Nokogiri Upgrade Part 1 - Always double quote XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,8 +585,8 @@ to specify different certificates for each function.
 You may also globally set the SP signature and digest method, to be used in SP signing (functions 1 and 2 above):
 
 ```ruby
-settings.security[:digest_method]    = RubySaml::XML::Document::SHA1
-settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA1
+settings.security[:digest_method]    = RubySaml::XML::Crypto::SHA1
+settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA1
 ```
 
 #### Signing SP Metadata

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -37,8 +37,7 @@ codebase for `RubySaml::XML::` and replace it as appropriate. In addition, you m
 `require 'xml_security'` with `require 'ruby_saml/xml'`.
 
 For backward compatibility, the alias `XMLSecurity = RubySaml::XML` has been set, so `RubySaml::XML::` will still work
-as before, unless you have defined `XMLSecurity` prior to loading RubySaml.
-In addition, a shim file has been added so that `require 'xml_security'` continues to work.
+as before. In addition, a shim file has been added so that `require 'xml_security'` continues to work.
 These aliases will be removed in RubySaml version `2.1.0`.
 
 ### Security: Change default hashing algorithm to SHA-256 (was SHA-1)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -37,7 +37,8 @@ codebase for `RubySaml::XML::` and replace it as appropriate. In addition, you m
 `require 'xml_security'` with `require 'ruby_saml/xml'`.
 
 For backward compatibility, the alias `XMLSecurity = RubySaml::XML` has been set, so `RubySaml::XML::` will still work
-as before. In addition, a shim file has been added so that `require 'xml_security'` continues to work.
+as before, unless you have defined `XMLSecurity` prior to loading RubySaml.
+In addition, a shim file has been added so that `require 'xml_security'` continues to work.
 These aliases will be removed in RubySaml version `2.1.0`.
 
 ### Security: Change default hashing algorithm to SHA-256 (was SHA-1)
@@ -57,6 +58,23 @@ you may set `RubySaml::Settings` as follows:
 settings.idp_cert_fingerprint_algorithm = RubySaml::XML::Crypto::SHA1
 settings.security[:digest_method] = RubySaml::XML::Crypto::SHA1
 settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA1
+```
+
+### Behavior change of double_quote_xml_attribute_values setting
+
+`settings.double_quote_xml_attribute_values` now always behaves as if it is set to `true`,
+i.e. RubySaml now always uses double quotes for attribute values when generating XML.
+
+The reasons for this change are:
+- RubySaml will use Nokogiri instead of REXML to generate XML. Nokogiri does not support
+  generating XML with single quotes.
+- Double quotes in XML tends to be the standard; there are no known SAML clients in the wild
+  which cannot support double-quoted XML.
+
+If you require to use single quotes in your XML output, you may try the following Regexp:
+
+```ruby
+
 ```
 
 ### Removal of embed_sign setting

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -62,20 +62,15 @@ settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA1
 
 ### Behavior change of double_quote_xml_attribute_values setting
 
-`settings.double_quote_xml_attribute_values` now always behaves as if it is set to `true`,
-i.e. RubySaml now always uses double quotes for attribute values when generating XML.
+RubySaml now always uses double quotes for attribute values when generating XML.
+The `settings.double_quote_xml_attribute_values` parameter now always behaves as `true`,
+and will be removed in RubySaml 2.1.0.
 
 The reasons for this change are:
 - RubySaml will use Nokogiri instead of REXML to generate XML. Nokogiri does not support
   generating XML with single quotes.
-- Double quotes in XML tends to be the standard; there are no known SAML clients in the wild
-  which cannot support double-quoted XML.
-
-If you require to use single quotes in your XML output, you may try the following Regexp:
-
-```ruby
-
-```
+- Double-quoted XML attributes are more commonly used than single quotes. There are no known
+  SAML clients which cannot support double-quoted XML.
 
 ### Removal of embed_sign setting
 

--- a/lib/ruby_saml/authrequest.rb
+++ b/lib/ruby_saml/authrequest.rb
@@ -100,6 +100,7 @@ module RubySaml
       assign_uuid(settings)
 
       request_doc = RubySaml::XML::Document.new
+      request_doc.context[:attribute_quote] = :quote
       request_doc.uuid = uuid
 
       root = request_doc.add_element "samlp:AuthnRequest", { "xmlns:samlp" => "urn:oasis:names:tc:SAML:2.0:protocol", "xmlns:saml" => "urn:oasis:names:tc:SAML:2.0:assertion" }

--- a/lib/ruby_saml/authrequest.rb
+++ b/lib/ruby_saml/authrequest.rb
@@ -54,7 +54,7 @@ module RubySaml
       end
 
       request_doc = create_authentication_xml_doc(settings)
-      request_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
+      request_doc.context[:attribute_quote] = :quote
 
       request = +""
       request_doc.write(request)

--- a/lib/ruby_saml/logoutrequest.rb
+++ b/lib/ruby_saml/logoutrequest.rb
@@ -52,7 +52,7 @@ module RubySaml
       end
 
       request_doc = create_logout_request_xml_doc(settings)
-      request_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
+      request_doc.context[:attribute_quote] = :quote
 
       request = +""
       request_doc.write(request)

--- a/lib/ruby_saml/logoutrequest.rb
+++ b/lib/ruby_saml/logoutrequest.rb
@@ -98,6 +98,7 @@ module RubySaml
       assign_uuid(settings)
 
       request_doc = RubySaml::XML::Document.new
+      request_doc.context[:attribute_quote] = :quote
       request_doc.uuid = uuid
 
       root = request_doc.add_element "samlp:LogoutRequest", { "xmlns:samlp" => "urn:oasis:names:tc:SAML:2.0:protocol", "xmlns:saml" => "urn:oasis:names:tc:SAML:2.0:assertion" }

--- a/lib/ruby_saml/metadata.rb
+++ b/lib/ruby_saml/metadata.rb
@@ -22,6 +22,7 @@ module RubySaml
     #
     def generate(settings, pretty_print=false, valid_until=nil, cache_duration=nil)
       meta_doc = RubySaml::XML::Document.new
+      meta_doc.context[:attribute_quote] = :quote
       add_xml_declaration(meta_doc)
       root = add_root_element(meta_doc, settings, valid_until, cache_duration)
       sp_sso = add_sp_sso_element(root, settings)

--- a/lib/ruby_saml/settings.rb
+++ b/lib/ruby_saml/settings.rb
@@ -252,11 +252,13 @@ module RubySaml
       # @deprecated Will be removed in v2.1.0
       define_method(old_param) do
         removed_deprecation(old_param, new_value)
+        new_value
       end
 
       # @deprecated Will be removed in v2.1.0
       define_method(:"#{old_param}=") do |_|
         removed_deprecation(old_param, new_value)
+        new_value
       end
     end
 

--- a/lib/ruby_saml/settings.rb
+++ b/lib/ruby_saml/settings.rb
@@ -54,7 +54,6 @@ module RubySaml
     attr_accessor :name_identifier_value
     attr_accessor :name_identifier_value_requested
     attr_accessor :sessionindex
-    attr_accessor :double_quote_xml_attribute_values
     attr_accessor :message_max_bytesize
     attr_accessor :passive
     attr_reader   :protocol_binding
@@ -230,7 +229,6 @@ module RubySaml
       idp_cert_fingerprint_algorithm: RubySaml::XML::Crypto::SHA256,
       message_max_bytesize: 250_000,
       soft: true,
-      double_quote_xml_attribute_values: false,
       security: {
         authn_requests_signed: false,
         logout_requests_signed: false,
@@ -247,6 +245,20 @@ module RubySaml
         lowercase_url_encoding: false
       }.freeze
     }.freeze
+
+    {
+      double_quote_xml_attribute_values: true
+    }.each do |old_param, new_value|
+      # @deprecated Will be removed in v2.1.0
+      define_method(old_param) do
+        removed_deprecation(old_param, new_value)
+      end
+
+      # @deprecated Will be removed in v2.1.0
+      define_method(:"#{old_param}=") do |_|
+        removed_deprecation(old_param, new_value)
+      end
+    end
 
     {
       issuer: :sp_entity_id,
@@ -354,6 +366,12 @@ module RubySaml
     end
 
     private
+
+    # @deprecated Will be removed in v2.1.0
+    def removed_deprecation(old_param, new_value)
+      Logging.deprecate "`RubySaml::Settings##{old_param}` is deprecated and will be removed in RubySaml 2.1.0. " \
+                        "It no longer has any effect, and will behave as if always set to #{new_value.inspect}."
+    end
 
     # @deprecated Will be removed in v2.1.0
     def replaced_deprecation(old_param, new_param)

--- a/lib/ruby_saml/slo_logoutresponse.rb
+++ b/lib/ruby_saml/slo_logoutresponse.rb
@@ -109,6 +109,7 @@ module RubySaml
       assign_uuid(settings)
 
       response_doc = RubySaml::XML::Document.new
+      response_doc.context[:attribute_quote] = :quote
       response_doc.uuid = uuid
 
       destination = settings.idp_slo_response_service_url || settings.idp_slo_service_url

--- a/lib/ruby_saml/slo_logoutresponse.rb
+++ b/lib/ruby_saml/slo_logoutresponse.rb
@@ -60,7 +60,7 @@ module RubySaml
       end
 
       response_doc = create_logout_response_xml_doc(settings, request_id, logout_message, logout_status_code)
-      response_doc.context[:attribute_quote] = :quote if settings.double_quote_xml_attribute_values
+      response_doc.context[:attribute_quote] = :quote
 
       response = +""
       response_doc.write(response)

--- a/test/authrequest_test.rb
+++ b/test/authrequest_test.rb
@@ -36,7 +36,7 @@ class AuthrequestTest < Minitest::Test
       zstream.finish
       zstream.close
 
-      assert_match(/<samlp:AuthnRequest[^<]* Destination='http:\/\/example.com'/, inflated)
+      assert_match(/<samlp:AuthnRequest[^<]* Destination="http:\/\/example\.com"/, inflated)
     end
 
     it "create the SAMLRequest URL parameter without deflating" do
@@ -61,7 +61,7 @@ class AuthrequestTest < Minitest::Test
       zstream.finish
       zstream.close
 
-      assert_match(/<samlp:AuthnRequest[^<]* IsPassive='true'/, inflated)
+      assert_match(/<samlp:AuthnRequest[^<]* IsPassive="true"/, inflated)
     end
 
     it "create the SAMLRequest URL parameter with ProtocolBinding" do
@@ -76,7 +76,7 @@ class AuthrequestTest < Minitest::Test
       zstream.finish
       zstream.close
 
-      assert_match(/<samlp:AuthnRequest[^<]* ProtocolBinding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'/, inflated)
+      assert_match(/<samlp:AuthnRequest[^<]* ProtocolBinding="urn:oasis:names:tc:SAML:2\.0:bindings:HTTP-POST"/, inflated)
     end
 
     it "create the SAMLRequest URL parameter with AttributeConsumingServiceIndex" do
@@ -90,7 +90,7 @@ class AuthrequestTest < Minitest::Test
       inflated = zstream.inflate(decoded)
       zstream.finish
       zstream.close
-      assert_match(/<samlp:AuthnRequest[^<]* AttributeConsumingServiceIndex='30'/, inflated)
+      assert_match(/<samlp:AuthnRequest[^<]* AttributeConsumingServiceIndex="30"/, inflated)
     end
 
     it "create the SAMLRequest URL parameter with ForceAuthn" do
@@ -104,7 +104,7 @@ class AuthrequestTest < Minitest::Test
       inflated = zstream.inflate(decoded)
       zstream.finish
       zstream.close
-      assert_match(/<samlp:AuthnRequest[^<]* ForceAuthn='true'/, inflated)
+      assert_match(/<samlp:AuthnRequest[^<]* ForceAuthn="true"/, inflated)
     end
 
     it "create the SAMLRequest URL parameter with NameID Format" do
@@ -118,8 +118,8 @@ class AuthrequestTest < Minitest::Test
       zstream.finish
       zstream.close
 
-      assert_match(/<samlp:NameIDPolicy[^<]* AllowCreate='true'/, inflated)
-      assert_match(/<samlp:NameIDPolicy[^<]* Format='urn:oasis:names:tc:SAML:2.0:nameid-format:transient'/, inflated)
+      assert_match(/<samlp:NameIDPolicy[^<]* AllowCreate="true"/, inflated)
+      assert_match(/<samlp:NameIDPolicy[^<]* Format="urn:oasis:names:tc:SAML:2\.0:nameid-format:transient"/, inflated)
     end
 
     it "create the SAMLRequest URL parameter with Subject" do
@@ -135,8 +135,8 @@ class AuthrequestTest < Minitest::Test
       zstream.close
 
       assert inflated.include?('<saml:Subject>')
-      assert inflated.include?("<saml:NameID Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'>testuser@example.com</saml:NameID>")
-      assert inflated.include?("<saml:SubjectConfirmation Method='urn:oasis:names:tc:SAML:2.0:cm:bearer'/>")
+      assert inflated.include?('<saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">testuser@example.com</saml:NameID>')
+      assert inflated.include?('<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>')
     end
 
     it "accept extra parameters" do
@@ -199,9 +199,9 @@ class AuthrequestTest < Minitest::Test
 
       it "can mutate the uuid" do
         request = RubySaml::Authrequest.new
-        request_id = request.request_id
         assert_nil request.uuid
-        assert_nil request_id
+        assert_nil request.request_id
+
         request.uuid = "new_uuid"
         assert_equal "new_uuid", request.uuid
         assert_equal request.uuid, request.request_id
@@ -225,7 +225,7 @@ class AuthrequestTest < Minitest::Test
       it "create the SAMLRequest parameter correctly" do
 
         auth_url = RubySaml::Authrequest.new.create(settings)
-        assert_match(/^http:\/\/example.com\?SAMLRequest/, auth_url)
+        assert_match(/^http:\/\/example\.com\?SAMLRequest/, auth_url)
       end
     end
 
@@ -234,7 +234,7 @@ class AuthrequestTest < Minitest::Test
         settings.idp_sso_service_url = "http://example.com?field=value"
 
         auth_url = RubySaml::Authrequest.new.create(settings)
-        assert_match(/^http:\/\/example.com\?field=value&SAMLRequest/, auth_url)
+        assert_match(/^http:\/\/example\.com\?field=value&SAMLRequest/, auth_url)
       end
     end
 
@@ -254,7 +254,7 @@ class AuthrequestTest < Minitest::Test
     it "create the saml:AuthnContextClassRef with comparison exact" do
       settings.authn_context = 'secure/name/password/uri'
       auth_doc = RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
-      assert_match(/<samlp:RequestedAuthnContext[\S ]+Comparison='exact'/, auth_doc.to_s)
+      assert_match(/<samlp:RequestedAuthnContext[\S ]+Comparison="exact"/, auth_doc.to_s)
       assert_match(/<saml:AuthnContextClassRef>secure\/name\/password\/uri<\/saml:AuthnContextClassRef>/, auth_doc.to_s)
     end
 
@@ -262,14 +262,14 @@ class AuthrequestTest < Minitest::Test
       settings.authn_context = 'secure/name/password/uri'
       settings.authn_context_comparison = 'minimun'
       auth_doc = RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
-      assert_match(/<samlp:RequestedAuthnContext[\S ]+Comparison='minimun'/, auth_doc.to_s)
+      assert_match(/<samlp:RequestedAuthnContext[\S ]+Comparison="minimun"/, auth_doc.to_s)
       assert_match(/<saml:AuthnContextClassRef>secure\/name\/password\/uri<\/saml:AuthnContextClassRef>/, auth_doc.to_s)
     end
 
     it "create the saml:AuthnContextDeclRef element correctly" do
       settings.authn_context_decl_ref = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
       auth_doc = RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
-      assert_match(/<saml:AuthnContextDeclRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport<\/saml:AuthnContextDeclRef>/, auth_doc.to_s)
+      assert_match(/<saml:AuthnContextDeclRef>urn:oasis:names:tc:SAML:2\.0:ac:classes:PasswordProtectedTransport<\/saml:AuthnContextDeclRef>/, auth_doc.to_s)
     end
 
     it "create the saml:AuthnContextClassRef element correctly" do
@@ -281,7 +281,7 @@ class AuthrequestTest < Minitest::Test
     it "create the saml:AuthnContextClassRef with comparison exact" do
       settings.authn_context = 'secure/name/password/uri'
       auth_doc = RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
-      assert auth_doc.to_s =~ /<samlp:RequestedAuthnContext[\S ]+Comparison='exact'/
+      assert auth_doc.to_s =~ /<samlp:RequestedAuthnContext[\S ]+Comparison="exact"/
       assert auth_doc.to_s =~ /<saml:AuthnContextClassRef>secure\/name\/password\/uri<\/saml:AuthnContextClassRef>/
     end
 
@@ -289,14 +289,14 @@ class AuthrequestTest < Minitest::Test
       settings.authn_context = 'secure/name/password/uri'
       settings.authn_context_comparison = 'minimun'
       auth_doc = RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
-      assert auth_doc.to_s =~ /<samlp:RequestedAuthnContext[\S ]+Comparison='minimun'/
+      assert auth_doc.to_s =~ /<samlp:RequestedAuthnContext[\S ]+Comparison="minimun"/
       assert auth_doc.to_s =~ /<saml:AuthnContextClassRef>secure\/name\/password\/uri<\/saml:AuthnContextClassRef>/
     end
 
     it "create the saml:AuthnContextDeclRef element correctly" do
       settings.authn_context_decl_ref = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
       auth_doc = RubySaml::Authrequest.new.create_authentication_xml_doc(settings)
-      assert auth_doc.to_s =~ /<saml:AuthnContextDeclRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport<\/saml:AuthnContextDeclRef>/
+      assert auth_doc.to_s =~ /<saml:AuthnContextDeclRef>urn:oasis:names:tc:SAML:2\.0:ac:classes:PasswordProtectedTransport<\/saml:AuthnContextDeclRef>/
     end
 
     it "create multiple saml:AuthnContextDeclRef elements correctly " do
@@ -329,7 +329,7 @@ class AuthrequestTest < Minitest::Test
         unless sp_hash_algo == :sha256
           it 'using mixed signature and digest methods (signature SHA256)' do
             # RSA is ignored here; only the hash sp_key_algo is used
-            settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA256
+            settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA256
             params = RubySaml::Authrequest.new.create_params(settings)
             request_xml = Base64.decode64(params["SAMLRequest"])
 
@@ -339,7 +339,7 @@ class AuthrequestTest < Minitest::Test
           end
 
           it 'using mixed signature and digest methods (digest SHA256)' do
-            settings.security[:digest_method] = RubySaml::XML::Document::SHA256
+            settings.security[:digest_method] = RubySaml::XML::Crypto::SHA256
             params = RubySaml::Authrequest.new.create_params(settings)
             request_xml = Base64.decode64(params["SAMLRequest"])
 
@@ -428,7 +428,7 @@ class AuthrequestTest < Minitest::Test
         unless sp_hash_algo == :sha256
           it 'using mixed signature and digest methods (signature SHA256)' do
             # RSA is ignored here; only the hash sp_key_algo is used
-            settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA256
+            settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA256
             params = RubySaml::Authrequest.new.create_params(settings, :RelayState => 'http://example.com')
 
             assert params['SAMLRequest']
@@ -444,7 +444,7 @@ class AuthrequestTest < Minitest::Test
           end
 
           it 'using mixed signature and digest methods (digest SHA256)' do
-            settings.security[:digest_method] = RubySaml::XML::Document::SHA256
+            settings.security[:digest_method] = RubySaml::XML::Crypto::SHA256
             params = RubySaml::Authrequest.new.create_params(settings, :RelayState => 'http://example.com')
 
             assert params['SAMLRequest']
@@ -461,7 +461,7 @@ class AuthrequestTest < Minitest::Test
         end
 
         it "create a signature parameter using the first certificate and key" do
-          settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA1
+          settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA1
           settings.certificate = nil
           settings.private_key = nil
           cert, pkey = CertificateHelper.generate_pair(sp_key_algo)

--- a/test/idp_metadata_parser_test.rb
+++ b/test/idp_metadata_parser_test.rb
@@ -157,27 +157,27 @@ class IdpMetadataParserTest < Minitest::Test
       settings = idp_metadata_parser.parse(idp_metadata, {
         :settings => {
           :security => {
-            :digest_method => RubySaml::XML::Document::SHA256,
-            :signature_method => RubySaml::XML::Document::RSA_SHA256
+            :digest_method => RubySaml::XML::Crypto::SHA256,
+            :signature_method => RubySaml::XML::Crypto::RSA_SHA256
           }
         }
       })
       assert_equal "C4:C6:BD:41:EC:AD:57:97:CE:7B:7D:80:06:C3:E4:30:53:29:02:0B:DD:2D:47:02:9E:BD:85:AD:93:02:45:21", settings.idp_cert_fingerprint
-      assert_equal RubySaml::XML::Document::SHA256, settings.get_sp_digest_method
-      assert_equal RubySaml::XML::Document::RSA_SHA256, settings.get_sp_signature_method
+      assert_equal RubySaml::XML::Crypto::SHA256, settings.get_sp_digest_method
+      assert_equal RubySaml::XML::Crypto::RSA_SHA256, settings.get_sp_signature_method
     end
 
     it "merges results into given settings object" do
       settings = RubySaml::Settings.new(:security => {
-        :digest_method => RubySaml::XML::Document::SHA256,
-        :signature_method => RubySaml::XML::Document::RSA_SHA256
+        :digest_method => RubySaml::XML::Crypto::SHA256,
+        :signature_method => RubySaml::XML::Crypto::RSA_SHA256
       })
 
       RubySaml::IdpMetadataParser.new.parse(idp_metadata_descriptor, :settings => settings)
 
       assert_equal "C4:C6:BD:41:EC:AD:57:97:CE:7B:7D:80:06:C3:E4:30:53:29:02:0B:DD:2D:47:02:9E:BD:85:AD:93:02:45:21", settings.idp_cert_fingerprint
-      assert_equal RubySaml::XML::Document::SHA256, settings.get_sp_digest_method
-      assert_equal RubySaml::XML::Document::RSA_SHA256, settings.get_sp_signature_method
+      assert_equal RubySaml::XML::Crypto::SHA256, settings.get_sp_digest_method
+      assert_equal RubySaml::XML::Crypto::RSA_SHA256, settings.get_sp_signature_method
     end
   end
 
@@ -256,8 +256,8 @@ class IdpMetadataParserTest < Minitest::Test
       parsed_metadata = idp_metadata_parser.parse_to_hash(idp_metadata, {
         :settings => {
           :security => {
-            :digest_method => RubySaml::XML::Document::SHA256,
-            :signature_method => RubySaml::XML::Document::RSA_SHA256
+            :digest_method => RubySaml::XML::Crypto::SHA256,
+            :signature_method => RubySaml::XML::Crypto::RSA_SHA256
           }
         }
       })

--- a/test/logoutrequest_test.rb
+++ b/test/logoutrequest_test.rb
@@ -78,7 +78,7 @@ class RequestTest < Minitest::Test
         settings.idp_slo_service_url = "http://example.com?field=value"
 
         unauth_url = RubySaml::Logoutrequest.new.create(settings)
-        assert_match(/^http:\/\/example.com\?field=value&SAMLRequest/, unauth_url)
+        assert_match(/^http:\/\/example\.com\?field=value&SAMLRequest/, unauth_url)
       end
     end
 
@@ -90,7 +90,7 @@ class RequestTest < Minitest::Test
         unauth_url = unauth_req.create(settings)
 
         inflated = decode_saml_request_payload(unauth_url)
-        assert_match %r[ID='#{unauth_req.uuid}'], inflated
+        assert_match %r[ID="#{unauth_req.uuid}"], inflated
       end
     end
 
@@ -132,9 +132,9 @@ class RequestTest < Minitest::Test
 
       it "can mutate the uuid" do
         request = RubySaml::Logoutrequest.new
-        request_id = request.request_id
         assert_nil request.uuid
-        assert_nil request_id
+        assert_nil request.request_id
+
         request.uuid = "new_uuid"
         assert_equal "new_uuid", request.uuid
         assert_equal request.uuid, request.request_id
@@ -198,7 +198,7 @@ class RequestTest < Minitest::Test
         unless sp_hash_algo == :sha256
           it 'using mixed signature and digest methods (signature SHA256)' do
             # RSA is ignored here; only the hash sp_key_algo is used
-            settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA256
+            settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA256
             params = RubySaml::Logoutrequest.new.create_params(settings)
             request_xml = Base64.decode64(params["SAMLRequest"])
 
@@ -208,7 +208,7 @@ class RequestTest < Minitest::Test
           end
 
           it 'using mixed signature and digest methods (digest SHA256)' do
-            settings.security[:digest_method] = RubySaml::XML::Document::SHA256
+            settings.security[:digest_method] = RubySaml::XML::Crypto::SHA256
             params = RubySaml::Logoutrequest.new.create_params(settings)
             request_xml = Base64.decode64(params["SAMLRequest"])
 
@@ -294,7 +294,7 @@ class RequestTest < Minitest::Test
         unless sp_hash_algo == :sha256
           it 'using mixed signature and digest methods (signature SHA256)' do
             # RSA is ignored here; only the hash sp_key_algo is used
-            settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA256
+            settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA256
             params = RubySaml::Logoutrequest.new.create_params(settings, :RelayState => 'http://example.com')
 
             assert params['SAMLRequest']
@@ -310,7 +310,7 @@ class RequestTest < Minitest::Test
           end
 
           it 'using mixed signature and digest methods (digest SHA256)' do
-            settings.security[:digest_method] = RubySaml::XML::Document::SHA256
+            settings.security[:digest_method] = RubySaml::XML::Crypto::SHA256
             params = RubySaml::Logoutrequest.new.create_params(settings, :RelayState => 'http://example.com')
 
             assert params['SAMLRequest']

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -370,7 +370,7 @@ class MetadataTest < Minitest::Test
           unless sp_hash_algo == :sha256
             it 'using mixed signature and digest methods (signature SHA256)' do
               # RSA is ignored here; only the hash sp_key_algo is used
-              settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA256
+              settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA256
               signed_metadata = RubySaml::XML::SignedDocument.new(xml_text)
 
               assert_match(signature_value_matcher, xml_text)
@@ -381,7 +381,7 @@ class MetadataTest < Minitest::Test
             end
 
             it 'using mixed signature and digest methods (digest SHA256)' do
-              settings.security[:digest_method] = RubySaml::XML::Document::SHA256
+              settings.security[:digest_method] = RubySaml::XML::Crypto::SHA256
               signed_metadata = RubySaml::XML::SignedDocument.new(xml_text)
 
               assert_match(signature_value_matcher, xml_text)

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -16,8 +16,7 @@ class SettingsTest < Minitest::Test
         :idp_cert, :idp_cert_fingerprint, :idp_cert_fingerprint_algorithm, :idp_cert_multi,
         :idp_attribute_names, :issuer, :assertion_consumer_service_url, :single_logout_service_url,
         :sp_name_qualifier, :name_identifier_format, :name_identifier_value, :name_identifier_value_requested,
-        :sessionindex, :attributes_index, :passive, :force_authn,
-        :double_quote_xml_attribute_values, :message_max_bytesize,
+        :sessionindex, :attributes_index, :passive, :force_authn, :message_max_bytesize,
         :security, :certificate, :private_key, :certificate_new, :sp_cert_multi,
         :authn_context, :authn_context_comparison, :authn_context_decl_ref,
         :assertion_consumer_logout_service_url
@@ -95,13 +94,13 @@ class SettingsTest < Minitest::Test
     it "does not modify default security settings" do
       settings = RubySaml::Settings.new
       settings.security[:authn_requests_signed] = true
-      settings.security[:digest_method] = RubySaml::XML::Document::SHA512
-      settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA512
+      settings.security[:digest_method] = RubySaml::XML::Crypto::SHA512
+      settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA512
 
       new_settings = RubySaml::Settings.new
       assert_equal new_settings.security[:authn_requests_signed], false
-      assert_equal new_settings.get_sp_digest_method, RubySaml::XML::Document::SHA256
-      assert_equal new_settings.get_sp_signature_method, RubySaml::XML::Document::RSA_SHA256
+      assert_equal new_settings.get_sp_digest_method, RubySaml::XML::Crypto::SHA256
+      assert_equal new_settings.get_sp_signature_method, RubySaml::XML::Crypto::RSA_SHA256
     end
 
     it "overrides only provided security attributes passing a second parameter" do
@@ -556,7 +555,6 @@ class SettingsTest < Minitest::Test
         assert_equal expected_encryption, actual[:encryption].map { |ary| ary.map(&:to_pem) }
       end
 
-
       it 'handles OpenSSL::PKey::PKey objects for single case' do
         @settings.certificate = cert_text1
         @settings.private_key = OpenSSL::PKey::RSA.new(key_text1)
@@ -846,13 +844,13 @@ class SettingsTest < Minitest::Test
         end
 
         it 'uses RSA SHA256 by default' do
-          assert_equal RubySaml::XML::Document::SHA256, @settings.get_sp_digest_method
+          assert_equal RubySaml::XML::Crypto::SHA256, @settings.get_sp_digest_method
         end
 
         it 'can be set as a full string' do
-          @settings.security[:signature_method] = RubySaml::XML::Document::DSA_SHA1
+          @settings.security[:signature_method] = RubySaml::XML::Crypto::DSA_SHA1
 
-          assert_equal RubySaml::XML::Document::DSA_SHA1, @settings.get_sp_signature_method
+          assert_equal RubySaml::XML::Crypto::DSA_SHA1, @settings.get_sp_signature_method
         end
 
         it 'can be set as a short string' do
@@ -903,7 +901,7 @@ class SettingsTest < Minitest::Test
           end
 
           it 'can be set as a full string' do
-            @settings.security[:signature_method] = RubySaml::XML::Document::SHA1
+            @settings.security[:signature_method] = RubySaml::XML::Crypto::SHA1
 
             assert_equal signature_method(sp_key_algo, :sha1), @settings.get_sp_signature_method
           end
@@ -967,7 +965,7 @@ class SettingsTest < Minitest::Test
       end
 
       it 'can be set as full string' do
-        @settings.security[:digest_method] = RubySaml::XML::Document::SHA224
+        @settings.security[:digest_method] = RubySaml::XML::Crypto::SHA224
 
         assert_equal RubySaml::XML::Crypto::SHA224, @settings.get_sp_digest_method
       end

--- a/test/slo_logoutrequest_test.rb
+++ b/test/slo_logoutrequest_test.rb
@@ -59,12 +59,12 @@ class RubySamlTest < Minitest::Test
         settings.certificate = ruby_saml_cert_text
         settings.private_key = ruby_saml_key_text
         settings.idp_cert = ruby_saml_cert_text
-        settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA1
+        settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA1
         params = {}
         params['SAMLRequest'] = logout_request_deflated_base64
         params['RelayState'] = 'http://invalid.example.com'
         params['Signature'] = 'invalid_signature'
-        params['SigAlg'] = RubySaml::XML::Document::RSA_SHA1
+        params['SigAlg'] = RubySaml::XML::Crypto::RSA_SHA1
         options = {}
         options[:get_params] = params
 

--- a/test/slo_logoutresponse_test.rb
+++ b/test/slo_logoutresponse_test.rb
@@ -54,7 +54,7 @@ class SloLogoutresponseTest < Minitest::Test
       unauth_url = RubySaml::SloLogoutresponse.new.create(settings, logout_request.id)
 
       inflated = decode_saml_response_payload(unauth_url)
-      assert_match(/InResponseTo='_c0348950-935b-0131-1060-782bcb56fcaa'/, inflated)
+      assert_match(/InResponseTo="_c0348950-935b-0131-1060-782bcb56fcaa"/, inflated)
     end
 
     it "set a custom successful logout message on the response" do
@@ -69,7 +69,7 @@ class SloLogoutresponseTest < Minitest::Test
 
       inflated = decode_saml_response_payload(unauth_url)
       assert_match(/<samlp:StatusMessage>Custom Logout Message<\/samlp:StatusMessage>/, inflated)
-      assert_match(/<samlp:StatusCode Value='urn:oasis:names:tc:SAML:2.0:status:PartialLogout/, inflated)
+      assert_match(/<samlp:StatusCode Value="urn:oasis:names:tc:SAML:2\.0:status:PartialLogout/, inflated)
     end
 
     it "uses the response location when set" do
@@ -79,7 +79,7 @@ class SloLogoutresponseTest < Minitest::Test
       assert_match(/^http:\/\/unauth\.com\/logout\/return\?SAMLResponse=/, unauth_url)
 
       inflated = decode_saml_response_payload(unauth_url)
-      assert_match(/Destination='http:\/\/unauth.com\/logout\/return'/, inflated)
+      assert_match(/Destination="http:\/\/unauth\.com\/logout\/return"/, inflated)
     end
 
     describe "uuid" do
@@ -122,6 +122,7 @@ class SloLogoutresponseTest < Minitest::Test
         response = RubySaml::SloLogoutresponse.new
         assert_nil response.uuid
         assert_nil response.response_id
+
         response.uuid = "new_uuid"
         assert_equal "new_uuid", response.uuid
         assert_equal response.uuid, response.response_id
@@ -186,7 +187,7 @@ class SloLogoutresponseTest < Minitest::Test
         unless sp_hash_algo == :sha256
           it 'using mixed signature and digest methods (signature SHA256)' do
             # RSA is ignored here; only the hash sp_key_algo is used
-            settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA256
+            settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA256
             logout_request.settings = settings
             params = RubySaml::SloLogoutresponse.new.create_params(settings, logout_request.id, "Custom Logout Message")
             response_xml = Base64.decode64(params["SAMLResponse"])
@@ -197,7 +198,7 @@ class SloLogoutresponseTest < Minitest::Test
           end
 
           it 'using mixed signature and digest methods (digest SHA256)' do
-            settings.security[:digest_method] = RubySaml::XML::Document::SHA256
+            settings.security[:digest_method] = RubySaml::XML::Crypto::SHA256
             logout_request.settings = settings
             params = RubySaml::SloLogoutresponse.new.create_params(settings, logout_request.id, "Custom Logout Message")
             response_xml = Base64.decode64(params["SAMLResponse"])
@@ -287,7 +288,7 @@ class SloLogoutresponseTest < Minitest::Test
         unless sp_hash_algo == :sha256
           it 'using mixed signature and digest methods (signature SHA256)' do
             # RSA is ignored here; only the hash sp_key_algo is used
-            settings.security[:signature_method] = RubySaml::XML::Document::RSA_SHA256
+            settings.security[:signature_method] = RubySaml::XML::Crypto::RSA_SHA256
             logout_request.settings = settings
             params = RubySaml::SloLogoutresponse.new.create_params(settings, logout_request.id, "Custom Logout Message", :RelayState => 'http://example.com')
 
@@ -304,7 +305,7 @@ class SloLogoutresponseTest < Minitest::Test
           end
 
           it 'using mixed signature and digest methods (digest SHA256)' do
-            settings.security[:digest_method] = RubySaml::XML::Document::SHA256
+            settings.security[:digest_method] = RubySaml::XML::Crypto::SHA256
             logout_request.settings = settings
             params = RubySaml::SloLogoutresponse.new.create_params(settings, logout_request.id, "Custom Logout Message", :RelayState => 'http://example.com')
 

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -138,8 +138,8 @@ class XmlTest < Minitest::Test
       sha1_fingerprint = "F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72"
       sha1_fingerprint_downcase = sha1_fingerprint.tr(':', '').downcase
 
-      assert response_fingerprint_test.document.validate_document(sha1_fingerprint, true, fingerprint_alg: RubySaml::XML::Document::SHA1)
-      assert response_fingerprint_test.document.validate_document(sha1_fingerprint_downcase, true, fingerprint_alg: RubySaml::XML::Document::SHA1)
+      assert response_fingerprint_test.document.validate_document(sha1_fingerprint, true, fingerprint_alg: RubySaml::XML::Crypto::SHA1)
+      assert response_fingerprint_test.document.validate_document(sha1_fingerprint_downcase, true, fingerprint_alg: RubySaml::XML::Crypto::SHA1)
     end
 
     it "validate using SHA256" do
@@ -147,24 +147,24 @@ class XmlTest < Minitest::Test
       sha256_fingerprint_downcase = sha256_fingerprint.tr(':', '').downcase
 
       assert response_fingerprint_test.document.validate_document(sha256_fingerprint)
-      assert response_fingerprint_test.document.validate_document(sha256_fingerprint, true, fingerprint_alg: RubySaml::XML::Document::SHA256)
+      assert response_fingerprint_test.document.validate_document(sha256_fingerprint, true, fingerprint_alg: RubySaml::XML::Crypto::SHA256)
 
       assert response_fingerprint_test.document.validate_document(sha256_fingerprint_downcase)
-      assert response_fingerprint_test.document.validate_document(sha256_fingerprint_downcase, true, fingerprint_alg: RubySaml::XML::Document::SHA256)
+      assert response_fingerprint_test.document.validate_document(sha256_fingerprint_downcase, true, fingerprint_alg: RubySaml::XML::Crypto::SHA256)
     end
 
     it "validate using SHA384" do
       sha384_fingerprint = "98:FE:17:90:31:E7:68:18:8A:65:4D:DA:F5:76:E2:09:97:BE:8B:E3:7E:AA:8D:63:64:7C:0C:38:23:9A:AC:A2:EC:CE:48:A6:74:4D:E0:4C:50:80:40:B4:8D:55:14:14"
 
       assert !response_fingerprint_test.document.validate_document(sha384_fingerprint)
-      assert response_fingerprint_test.document.validate_document(sha384_fingerprint, true, :fingerprint_alg => RubySaml::XML::Document::SHA384)
+      assert response_fingerprint_test.document.validate_document(sha384_fingerprint, true, :fingerprint_alg => RubySaml::XML::Crypto::SHA384)
     end
 
     it "validate using SHA512" do
       sha512_fingerprint = "5A:AE:BA:D0:BA:9D:1E:25:05:01:1E:1A:C9:E9:FF:DB:ED:FA:6E:F7:52:EB:45:49:BD:DB:06:D8:A3:7E:CC:63:3A:04:A2:DD:DF:EE:61:05:D9:58:95:2A:77:17:30:4B:EB:4A:9F:48:4A:44:1C:D0:9E:0B:1E:04:77:FD:A3:D2"
 
       assert !response_fingerprint_test.document.validate_document(sha512_fingerprint)
-      assert response_fingerprint_test.document.validate_document(sha512_fingerprint, true, fingerprint_alg: RubySaml::XML::Document::SHA512)
+      assert response_fingerprint_test.document.validate_document(sha512_fingerprint, true, fingerprint_alg: RubySaml::XML::Crypto::SHA512)
     end
 
   end


### PR DESCRIPTION
@pitbulk this PR deprecates `double_quote_xml_attribute_values` and always makes it behave as true. The reason is that Nokogiri can't generate single quoted XML, and there's no reason to support it.

The PR also includes migration from `RubySaml::XML::Document::*` constants to `RubySaml::XML::Crypto::*`, mainly in tests.

Coveralls failures can be ignored; its just for deprecated code that will be removed in future phases.

Please merge.