### PR TITLE
Update ruby-saml version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Using `Gemfile`
 
 ```ruby
 # latest stable
-gem 'ruby-saml', '~> 1.17.0'
+gem 'ruby-saml', '~> 1.18.0'
 
 # or track master for bleeding-edge
 gem 'ruby-saml', :github => 'saml-toolkit/ruby-saml'


### PR DESCRIPTION
## Context

Since version 1.18 fixes vulnerabilities, we should encourage people to use the latest version.